### PR TITLE
RJSF Docs Update

### DIFF
--- a/docs/bundles/11-custom-widgets.md
+++ b/docs/bundles/11-custom-widgets.md
@@ -201,7 +201,7 @@ duration:
 
 ### Container Repositories
 
-The `ContainerRepositoriesDropdown` is an asynchronous dropdown field that queries for and populates with an organization's container repositories currently connected with Massdriver. Once selected, the container repository's `cloudProviderId` will be added to the `formData`. This dropdown also supports external filtering via a `cloud` type. Pass a specific `cloud` (`aws`, `gcp`, or `azure`) externally via the `uiSchema` to control what the `ContainerRepositoriesDropdown` displays.
+The `ContainerRepositoriesDropdown` is an asynchronous dropdown field that queries for and populates with an organization's container repositories currently connected with Massdriver. Once selected, the container repository's `cloudProviderId` will be added to the `formData`. This dropdown also supports external filtering via a `cloud` type. Pass a specific `cloud` (`aws`, `gcp`, or `azure`) externally via the `uiSchema` to control what the `ContainerRepositoriesDropdown` displays. You can also pass a specific `returnType` (`cloudProviderId` or `cloudProviderURI`) externally via the `uiSchema` to control what the `ContainerRepositoriesDropdown` returns. Any attribute associated with a `containerRepository` (`name`, `id`, `cloud`, `location`, etc) is a valid `returnType`, but be sure to only pass unique values, like `id`, to have all the visual aspects work properly.
 
 **Props**
 
@@ -210,6 +210,7 @@ External props passed through the `uiSchema`
 | Name         |  Required    |  Type       |    Default  |   Example  | Description |
 | ------------ | -----------  | ----------- | ----------- | -----------| ----------- |
 | cloud        |  False       | string      |   undefined | `aws`, `gcp`, `azure`  | A string that, if provided, constrain the contents of the field by cloud type. |
+| returnType   |  False       | string      |   cloudProviderId | `cloudProviderId`, `cloudProviderURI`  |A string that decides what value gets returned from the field. It allows any `containerRepository` attribute, but one should only pass unique values like `id` to ensure all the visual aspects work as intended. If an invalid `returnType` is passed, the field will default to `cloudProviderId`. |
 
 
 **Example**
@@ -230,6 +231,7 @@ properties:
 containerRepositories:
   ui:field: containerRepositoriesDropdown
   cloud: aws
+  returnType: cloudProviderURI
 ```
 
 ### DNS Zones


### PR DESCRIPTION
Updates RJSF Docs to reflect the `returnType` addition to the `containerRepositoriesDropdown` field.