### PR TITLE
Enhance SCIM documentation with user provisioning details

### DIFF
--- a/docs/reference/integrations/03-scim.md
+++ b/docs/reference/integrations/03-scim.md
@@ -29,7 +29,7 @@ Massdriver provisions a SCIM endpoint and generates a bearer token for authentic
 Using the values provided by Massdriver, configure SCIM provisioning in your IdP:
 
 | Field | Description | Source |
-|-------|-------------|--------|
+| --- | --- | --- |
 | SCIM Endpoint URL | The URL your IdP sends provisioning requests to | Provided after integration creation |
 | Bearer Token | Authentication token for SCIM requests | Provided after integration creation |
 
@@ -43,6 +43,44 @@ Refer to your identity provider's documentation for specific setup instructions:
 ### Step 3: Test the Connection
 
 Most identity providers include a **Test Connection** button in their SCIM configuration. Use this to verify that your IdP can reach the Massdriver SCIM endpoint and authenticate successfully.
+
+## Controlling Which Users Are Provisioned
+
+By default, most identity providers will attempt to provision all assigned users to Massdriver. If you only want a subset of your directory to have access, each IdP offers its own mechanism for scoping which users are synced.
+
+### Microsoft Entra ID (Azure AD): Scoping Filters
+
+Entra ID supports **attribute-based scoping filters** that let you define rules for which users are provisioned. For example, you can provision only users whose `department` equals `Engineering` or whose `userPrincipalName` matches a specific domain.
+
+Scoping filters are configured in the **Provisioning > Mappings** section of your enterprise application. Each filter consists of one or more clauses evaluated with AND logic. Multiple filters are evaluated with OR logic — a user matching any filter is provisioned.
+
+Common examples include filtering by department, email domain (via regex on `userPrincipalName`), or employee ID range.
+
+For full instructions, see [Scoping users or groups with scoping filters](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/define-conditional-rules-for-provisioning-user-accounts).
+
+### Okta: User and Group Assignments
+
+Okta controls provisioning scope through **application assignments**. Only users or groups explicitly assigned to the Massdriver application in Okta will be provisioned.
+
+To scope provisioning, navigate to your Massdriver application in the Okta Admin Console and use the **Assignments** tab to add specific users or groups. Members of assigned groups are automatically provisioned when they are added and deprovisioned when they are removed.
+
+For details, see [SCIM app integrations](https://help.okta.com/en-us/content/topics/apps/apps-about-scim.htm).
+
+### OneLogin: Roles and Provisioning Rules
+
+OneLogin controls which users are provisioned based on **application assignments and roles**. Only users assigned to the Massdriver application (directly or via a OneLogin role) are provisioned.
+
+For more granular control, you can use **Rules** under the application's Rules tab. Rules let you filter users by attribute values (e.g., department, role name) and control which subset of users is provisioned or how they are mapped to groups.
+
+For details, see [Introduction to User Provisioning](https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010298).
+
+### JumpCloud: User Group Assignments
+
+JumpCloud scopes SCIM provisioning through **user groups**. Rather than assigning individual users, you assign user groups to the Massdriver application. Only users who are members of the assigned groups will be provisioned.
+
+To configure scoping, navigate to your Massdriver application in the JumpCloud Admin Console, select the **User Groups** tab, and select the groups you want to sync. Users added to or removed from those groups will be provisioned or deprovisioned automatically.
+
+For details, see [Get Started: SCIM Identity Management](https://jumpcloud.com/support/get-started-identity-management-connectors).
 
 ## Supported Operations
 
@@ -65,3 +103,9 @@ Once configured, your identity provider can automatically:
 - Confirm that users or groups are assigned to the Massdriver application in your IdP
 - Check your IdP's provisioning logs for errors
 - Verify that SCIM provisioning is enabled (not just SSO)
+
+### Too many users are being provisioned
+
+- Review the scoping configuration for your identity provider (see [Controlling Which Users Are Provisioned](#controlling-which-users-are-provisioned) above)
+- For Entra ID, add a scoping filter to restrict provisioning to specific departments, domains, or user attributes
+- For Okta, OneLogin, and JumpCloud, verify that only the intended users or groups are assigned to the Massdriver application


### PR DESCRIPTION
Added guidance on controlling user provisioning for various identity providers including Microsoft Entra ID, Okta, OneLogin, and JumpCloud.