### PR TITLE
Remove massdriver/ prefixes from artifact definitions

### DIFF
--- a/docs/applications/02-create-application.md
+++ b/docs/applications/02-create-application.md
@@ -58,19 +58,19 @@ Application templates are cached locally the first time `mass bundle new` is run
 
 Then, [`connections`](/concepts/connections) (your application dependencies) will need to be selected.
 
-For this example we'll choose [`massdriver/postgresql-authentication`](https://github.com/massdriver-cloud/artifact-definitions/blob/main/definitions/artifacts/postgresql-authentication.json).
+For this example we'll choose [`postgresql-authentication`](https://github.com/massdriver-cloud/artifact-definitions/blob/main/definitions/artifacts/postgresql-authentication.json).
 
 ```shell title="Prompt"
 ? What connections do you need?
   If you don't need any, just hit enter or select (None)
   [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
   [ ]  (None)
-  [ ]  massdriver/aws-dynamodb-table
+  [ ]  aws-dynamodb-table
   ...
-  [ ]  massdriver/mongo-authentication
-  [ ]  massdriver/mysql-authentication
-> [ ]  massdriver/postgresql-authentication
-  [ ]  massdriver/redis-authentication
+  [ ]  mongo-authentication
+  [ ]  mysql-authentication
+> [ ]  postgresql-authentication
+  [ ]  redis-authentication
 ```
 
 You'll be prompted to name the variable for each connection that you added. We suggest simple names like `postgres`, but if you have more complex dependencies it may make sense to use names like `inventory_database` for an inventory database or `website_cache` for a Redis website cache.
@@ -200,15 +200,15 @@ connections:
     - postgres
   properties:
     kubernetes_cluster:
-      $ref: massdriver/kubernetes-cluster
+      $ref: kubernetes-cluster
     aws_authentication:
-      $ref: massdriver/aws-iam-role
+      $ref: aws-iam-role
     gcp_authentication:
-      $ref: massdriver/gcp-service-account
+      $ref: gcp-service-account
     azure_authentication:
-      $ref: massdriver/azure-service-principal
+      $ref: azure-service-principal
     postgres:
-      $ref: massdriver/postgresql-authentication
+      $ref: postgresql-authentication
 ```
 
 If you followed the prompts in this guide, you should end up with an application bundle that looks like [this](https://github.com/massdriver-cloud/application-examples/tree/main/k8s/phoenix-chat-example).

--- a/docs/applications/03-deploying-application.md
+++ b/docs/applications/03-deploying-application.md
@@ -43,9 +43,9 @@ Add and connect the following resources from the bundle sidebar. To expand the s
 
 You'll need to add:
 
-* massdriver/aws-vpc
-* massdriver/aws-eks-cluster
-* massdriver/aws-rds-postgres or massdriver/aws-aurora-serverless-postgres
+* aws-vpc
+* aws-eks-cluster
+* aws-rds-postgres or aws-aurora-serverless-postgres
 
 After adding each to the canvas, click on the package. Feel free to fine tune the configuration, but if you are new to cloud infrastructure the `Configuration Presets` are a great way to get started quickly. Select a preset like **Development** and then click **Deploy**.
 
@@ -53,7 +53,7 @@ After adding each to the canvas, click on the package. Feel free to fine tune th
 
 The artifact system in Massdriver (the boxes you connect lines to) shares common types between bundles to make it possible to swap between different infrastructure bundles that provide the same functionality.
 
-In this example you could use `massdriver/aws-rds-postgres`, `massdriver/aws-aurora-serverless-postgres`, or a version of PostgreSQL running on Kubernetes.
+In this example you could use `aws-rds-postgres`, `aws-aurora-serverless-postgres`, or a version of PostgreSQL running on Kubernetes.
 
 :::
 

--- a/docs/bundle-development/provisioners/02-opentofu.md
+++ b/docs/bundle-development/provisioners/02-opentofu.md
@@ -111,14 +111,14 @@ connections:
   - aws_authentication
   properties:
     aws_authentication:
-      $ref: massdriver/aws-iam-role
+      $ref: aws-iam-role
 
 artifacts:
   required:
     - bucket
   properties:
     bucket:
-      $ref: massdriver/aws-s3-bucket
+      $ref: aws-s3-bucket
 ```
 
 Since the artifact is named `bucket` a file named `artifact_bucket.jq` would need to be in the module directory and the provisioner would use this file as a JQ template, passing the params, connections and outputs to it. There are two approaches to building the proper artifact structure:

--- a/docs/bundle-development/provisioners/03-terraform.md
+++ b/docs/bundle-development/provisioners/03-terraform.md
@@ -111,14 +111,14 @@ connections:
   - aws_authentication
   properties:
     aws_authentication:
-      $ref: massdriver/aws-iam-role
+      $ref: aws-iam-role
 
 artifacts:
   required:
     - bucket
   properties:
     bucket:
-      $ref: massdriver/aws-s3-bucket
+      $ref: aws-s3-bucket
 ```
 
 Since the artifact is named `bucket` a file named `artifact_bucket.jq` would need to be in the module directory and the provisioner would use this file as a JQ template, passing the params, connections and outputs to it. There are two approaches to building the proper artifact structure:

--- a/docs/bundle-development/provisioners/04-helm.md
+++ b/docs/bundle-development/provisioners/04-helm.md
@@ -25,7 +25,7 @@ The following configuration options are available:
 
 | Configuration Option | Type | Default | Description |
 |-|-|-|-|
-| `kubernetes_cluster` | object | `.connections.kubernetes_cluster` | `jq` path to a `massdriver/kubernetes-cluster` connection for authentication to Kubernetes |
+| `kubernetes_cluster` | object | `.connections.kubernetes_cluster` | `jq` path to a `kubernetes-cluster` connection for authentication to Kubernetes |
 | `namespace` | string | `"default"` | Kubernetes namespace to install the chart into. Defaults to the `default` namespace |
 | `release_name` | string | (package name) | Specifies the release name for the helm chart. Defaults to the Massdriver package name if not specified. |
 | `.chart.repo` | string | `null` | Specifies the URL of the chart repo (required if using [remote chart](#local-vs-remote-chart-vs-oci-chart)) |
@@ -108,7 +108,7 @@ deployment:
     envs: {}
 ```
 
-To properly set these values in a Massdriver bundle, we likely would want the `commonLabels` value to come from [`md_metadata.default_tags`](https://docs.massdriver.cloud/bundles/development#massdriver-metadata), the `foo` value to come from params, and the `postgres` block to come from a connection. That means this bundle would require a `massdriver/postgres-authentication` connection named `database`. Since this is a Helm chart, it will also need a `massdriver/kubernetes-cluster` connection to provide authentication to the kubernetes cluster the chart is being installed into. The `massdriver.yaml` file would look something like:
+To properly set these values in a Massdriver bundle, we likely would want the `commonLabels` value to come from [`md_metadata.default_tags`](https://docs.massdriver.cloud/bundles/development#massdriver-metadata), the `foo` value to come from params, and the `postgres` block to come from a connection. That means this bundle would require a `postgres-authentication` connection named `database`. Since this is a Helm chart, it will also need a `kubernetes-cluster` connection to provide authentication to the kubernetes cluster the chart is being installed into. The `massdriver.yaml` file would look something like:
 
 ```yaml massdriver.yaml
 app:
@@ -135,9 +135,9 @@ connections:
     - database
   properties:
     kubernetes_cluster:
-      $ref: massdriver/kubernetes-cluster
+      $ref: kubernetes-cluster
     database:
-      $ref: massdriver/postgresql-authentication
+      $ref: postgresql-authentication
 ```
 ### params.jq
 
@@ -325,14 +325,14 @@ connections:
     - kubernetes_cluster
   properties:
     kubernetes_cluster:
-      $ref: massdriver/kubernetes-cluster
+      $ref: kubernetes-cluster
 
 artifacts:
   required:
     - api_endpoint
   properties:
     api_endpoint:
-      $ref: massdriver/api
+      $ref: api
 ```
 
 Since the artifact is named `api_endpoint` a file named `artifact_api_endpoint.jq` would need to be in the template directory and the provisioner would use this file as a JQ template, passing the params, connections and outputs to it. For this example, let's say the helm chart will produce two manifests: a `deployment`, and a `service`. The output of `helm get manifest` would be something like:

--- a/docs/bundle-development/provisioners/05-bicep.md
+++ b/docs/bundle-development/provisioners/05-bicep.md
@@ -25,7 +25,7 @@ The following configuration options are available:
 
 | Configuration Option | Type | Default | Description |
 |-|-|-|-|
-| `azure_service_principal` | object | `.connections.azure_service_principal` | `jq` path to a `massdriver/azure-service-principal` connection for authentication to Azure |
+| `azure_service_principal` | object | `.connections.azure_service_principal` | `jq` path to a `azure-service-principal` connection for authentication to Azure |
 | `location` | string | `"eastus"` | Azure region to deploy template resources into. Defaults to `"eastus"`. |
 | `scope` | string | `"group"` | Sets the [Azure Resource Manager deployment scope](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-cli#deployment-scope). Currently supports `group` and `sub`. For more information, refer to the [Deployment Scope](#deployment-scope) section. |
 | `complete` | boolean | `true` | Sets the [Azure Resource Manager deployment mode](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deployment-modes) to "Complete" (sets the `--mode Complete` flag). If this is set to `false`, deployment mode will be "Incremental". Only applies to steps with scope `group`. For more information, refer to the [Deployment Mode](#deployment-mode) section. |
@@ -124,14 +124,14 @@ connections:
     - azure_service_principal
   properties:
     azure_service_principal:
-      $ref: massdriver/azure-service-principal
+      $ref: azure-service-principal
 
 artifacts:
   required:
     - storage_account
   properties:
     storage_account:
-      $ref: massdriver/azure-storage-account-blob
+      $ref: azure-storage-account-blob
 ```
 
 Since the artifact is named `storage_account` a file named `artifact_storage_account.jq` would need to be in the template directory and the provisioner would use this file as a JQ template, passing the params, connections and outputs to it. There are two approaches to building the proper artifact structure:

--- a/docs/bundle-development/publishing/01-bundle-templates.md
+++ b/docs/bundle-development/publishing/01-bundle-templates.md
@@ -232,7 +232,7 @@ mass bundle new \
   --name my-new-bundle \
   --template-name opentofu-module \
   --output-directory ./my-new-bundle \
-  --connections aws_authentication=massdriver/aws-iam-role
+  --connections aws_authentication=aws-iam-role
 ```
 
 ## Template Best Practices
@@ -243,9 +243,9 @@ Always include the appropriate cloud credential connection for your target cloud
 
 | Cloud | Artifact Definition | Suggested Name |
 |-------|---------------------|----------------|
-| AWS | `massdriver/aws-iam-role` | `aws_authentication` |
-| GCP | `massdriver/gcp-service-account` | `gcp_authentication` |
-| Azure | `massdriver/azure-service-principal` | `azure_service_principal` |
+| AWS | `aws-iam-role` | `aws_authentication` |
+| GCP | `gcp-service-account` | `gcp_authentication` |
+| Azure | `azure-service-principal` | `azure_service_principal` |
 
 ### 2. Use Configuration Presets
 
@@ -336,14 +336,14 @@ connections:
     - aws_authentication
   properties:
     aws_authentication:
-      $ref: massdriver/aws-iam-role
+      $ref: aws-iam-role
 
 artifacts:
   required:
     - bucket
   properties:
     bucket:
-      $ref: massdriver/aws-s3-bucket
+      $ref: aws-s3-bucket
 
 ui:
   ui:order:

--- a/docs/bundle-development/schema-design/02-massdriver-annotations.md
+++ b/docs/bundle-development/schema-design/02-massdriver-annotations.md
@@ -109,7 +109,7 @@ connections:
     - postgres_cluster
   properties:
     postgres_cluster:
-      $ref: massdriver/postgresql-authentication
+      $ref: postgresql-authentication
 properties:
   database_instance:
     title: Database Instance
@@ -139,7 +139,7 @@ connections:
     - vpc
   properties:
     vpc:
-      $ref: massdriver/aws-vpc
+      $ref: aws-vpc
 properties:
   subnet_id:
     title: Subnet
@@ -172,7 +172,7 @@ connections:
     - security
   properties:
     security:
-      $ref: massdriver/aws-iam-role
+      $ref: aws-iam-role
 properties:
   iam_policy:
     title: IAM Policy
@@ -414,7 +414,7 @@ When an artifact is queried via GraphQL or REST API:
 
 ```yaml
 $md:
-  name: massdriver/postgresql-authentication
+  name: postgresql-authentication
 properties:
   username:
     type: string
@@ -501,7 +501,7 @@ connections:
     - vpc
   properties:
     vpc:
-      $ref: massdriver/aws-vpc
+      $ref: aws-vpc
 properties:
   identifier:
     title: Database Identifier

--- a/docs/concepts/02-artifacts-and-definitions.md
+++ b/docs/concepts/02-artifacts-and-definitions.md
@@ -92,7 +92,7 @@ connections:
     - vpc
   properties:
     vpc:
-      $ref: massdriver/aws-vpc
+      $ref: aws-vpc
 
 # Bundle produces a database artifact
 artifacts:
@@ -100,7 +100,7 @@ artifacts:
     - database
   properties:
     database:
-      $ref: massdriver/postgresql-authentication
+      $ref: postgresql-authentication
 ```
 
 ## Best Practices

--- a/docs/guides/bundle-from-opentofu.md
+++ b/docs/guides/bundle-from-opentofu.md
@@ -50,14 +50,14 @@ Be sure to complete the [prerequisites](https://docs.massdriver.cloud/getting-st
 
     | Cloud | Connection                           | Name                      |
     |-------|--------------------------------------|---------------------------|
-    | AWS   | `massdriver/aws-iam-role`            | `aws_authentication`      |
-    | GCP   | `massdriver/gcp-service-account`     | `gcp_authentication`      |
-    | Azure | `massdriver/azure-service-principal` | `azure_service_principal` |
+    | AWS   | `aws-iam-role`            | `aws_authentication`      |
+    | GCP   | `gcp-service-account`     | `gcp_authentication`      |
+    | Azure | `azure-service-principal` | `azure_service_principal` |
 
 5. Next you'll be prompted to name your connections. If you selected a cloud credential as a connection, use the appropriate name in the above table to simplify your bundle.
 
     ```bash
-    Please enter a name for the connection: "massdriver/aws-iam-role"
+    Please enter a name for the connection: "aws-iam-role"
     This will be the variable name used to reference it in your app|bundle IaC
     ✔ Name: aws_authentication
     ```

--- a/docs/reference/cli/commands/mass_bundle_new.md
+++ b/docs/reference/cli/commands/mass_bundle_new.md
@@ -24,13 +24,13 @@ To get started in interactive mode run `mass bundle new` then follow the prompts
 Create a new bundle using an existing OpenTofu module to populate params:
 
 ```shell
-mass bundle new -n foo -o massdriver -t opentofu-module -c network=massdriver/vpc -p /path/to/opentofu/dir
+mass bundle new -n foo -o massdriver -t opentofu-module -c network=vpc -p /path/to/opentofu/dir
 ```
 
 Create a new bundle using an existing Helm chart's values.yaml to populate params:
 
 ```shell
-mass bundle new -n foo -o massdriver -t helm-chart -c network=massdriver/vpc -p /path/to/helm/values.yaml
+mass bundle new -n foo -o massdriver -t helm-chart -c network=vpc -p /path/to/helm/values.yaml
 ```
 
 
@@ -41,7 +41,7 @@ mass bundle new [flags]
 ### Options
 
 ```
-  -c, --connections strings       Connections and names to add to the bundle - example: network=massdriver/vpc
+  -c, --connections strings       Connections and names to add to the bundle - example: network=vpc
   -d, --description string        Description of the new bundle
   -h, --help                      help for new
   -n, --name string               Name of the new bundle. Setting this along with --template-name will disable the interactive prompt.

--- a/docs/reference/cli/commands/mass_preview_init.md
+++ b/docs/reference/cli/commands/mass_preview_init.md
@@ -33,7 +33,7 @@ The `preview.json` file serves two purposes in your preview environment:
 {
   "credentials": {
     // Using an AWS IAM Role
-    "massdriver/aws-iam-role": "00000000-0000-0000-0000-000000000000"
+    "aws-iam-role": "00000000-0000-0000-0000-000000000000"
   },
   "packageParams": {
     "database": {


### PR DESCRIPTION
## Summary
- Public artifact definitions are no longer supported — the `massdriver/` prefix on connections and artifacts is now ignored
- Removed `massdriver/` prefix from all artifact/connection type references across 12 documentation files
- Preserved non-artifact `massdriver/` references (container filesystem paths, helm charts, terraform registry URLs, config paths, docker images)

## Files changed
- Bundle development docs: provisioners (helm, terraform, opentofu, bicep), schema design, bundle templates
- Concept docs: artifacts & definitions
- Guide docs: bundle from opentofu
- Application docs: create, deploy
- CLI reference: mass bundle new, mass preview init

## Test plan
- [x] `yarn build` succeeds with no errors
- [x] Verified all remaining `massdriver/` references are non-artifact (filesystem paths, helm charts, URLs, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)