### PR TITLE
Collapse instance:approve into instance:deploy in ABAC docs

### DIFF
--- a/docs/platform-operations/security/02-access-control.md
+++ b/docs/platform-operations/security/02-access-control.md
@@ -316,11 +316,10 @@ Massdriver defines 34 permissions using an `entity:verb` format.
 | Permission | Description |
 |---|---|
 | `instance:configure` | Set parameters, secrets, version, and remote references |
-| `instance:deploy` | Deploy infrastructure |
+| `instance:deploy` | Deploy infrastructure. Also approves or rejects proposed deployments — anyone who can deploy an instance can decide a proposal for it. |
 | `instance:plan` | Run an infrastructure plan without deploying |
 | `instance:decommission` | Tear down infrastructure |
 | `instance:propose` | Submit a deployment for approval |
-| `instance:approve` | Approve or reject a proposed deployment |
 
 ### Group
 
@@ -393,7 +392,7 @@ policies:
 
 ### SRE with Cross-Cutting Production Access
 
-SRE can see all projects, deploy and decommission anything in production, and approve deployments from any team.
+SRE can see all projects and deploy, decommission, or approve proposed deployments anywhere in production. `instance:deploy` covers both running a deployment and deciding a proposal submitted by another team.
 
 ```yaml
 group: sre
@@ -403,7 +402,7 @@ policies:
     conditions: "*"
 
   - effect: allow
-    action: [instance:deploy, instance:decommission, instance:approve]
+    action: [instance:deploy, instance:decommission]
     conditions: { md-environment: production }
 ```
 
@@ -739,7 +738,7 @@ policies:
     conditions: "*"
 
   - effect: allow
-    action: [instance:deploy, instance:decommission, instance:approve]
+    action: [instance:deploy, instance:decommission]
     conditions: { SRE_TEAM: koalas }
 
 group: appsec
@@ -783,15 +782,9 @@ policies:
   - effect: allow
     action: [instance:configure, instance:deploy, instance:plan, resource:update]
     conditions: { PURPOSE: [database, storage] }
-
-  - effect: allow
-    action: instance:approve
-    conditions:
-      PURPOSE: [database, storage]
-      md-environment: prod
 ```
 
-The DBA team can configure and deploy any database or storage component across every project and environment, with a stricter `instance:approve` scope tied to production specifically. A newly created project doesn't need to grant DBA access — as long as its database components are tagged `PURPOSE: database`, the existing policy applies automatically.
+The DBA team can configure, deploy, and decide proposed deployments for any database or storage component across every project and environment. `instance:deploy` covers both running a deployment and approving or rejecting one a product team has proposed. A newly created project doesn't need to grant DBA access — as long as its database components are tagged `PURPOSE: database`, the existing policy applies automatically.
 
 The same shape extends to other specialist functions:
 

--- a/docs/platform-operations/security/03-graphql-permissions.md
+++ b/docs/platform-operations/security/03-graphql-permissions.md
@@ -69,8 +69,8 @@ Deployments are an action *on* an instance — `createDeployment`, `proposeDeplo
 | `copyInstance` | Mutation | `project:view`, `instance:configure` | View on source instance, configure on destination. |
 | `createDeployment` | Mutation | `instance:deploy`, `instance:plan`, or `instance:decommission` | Permission depends on `input.action`: `PROVISION` → `instance:deploy`, `PLAN` → `instance:plan`, `DECOMMISSION` → `instance:decommission`. |
 | `proposeDeployment` | Mutation | `instance:propose` | Only `PROVISION` and `DECOMMISSION` are proposable. |
-| `approveDeployment` | Mutation | `instance:approve` | |
-| `rejectDeployment` | Mutation | `instance:approve` | Same permission as approve — both close out a proposal. |
+| `approveDeployment` | Mutation | `instance:deploy` | |
+| `rejectDeployment` | Mutation | `instance:deploy` | Same permission as approve — both close out a proposal. |
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

Mirrors the platform change in https://github.com/massdriver-cloud/massdriver/pull/3184, which removes `instance:approve` from the ABAC catalog and folds approve/reject of proposed deployments into `instance:deploy`.

- `docs/platform-operations/security/02-access-control.md` — drops the `instance:approve` row from the Instance permissions table, expands the `instance:deploy` description, and updates the SRE / koalas-sre / DBA examples (and surrounding prose) to match the new model.
- `docs/platform-operations/security/03-graphql-permissions.md` — `approveDeployment` and `rejectDeployment` now both list `instance:deploy` as the required permission.

## Test plan

- [ ] `rg "instance:approve" docs/` returns nothing.
- [ ] Spot-check the rendered Access Control and GraphQL permissions pages locally if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)