### PR TITLE
ABAC: split repo:grant / resource:grant out of repo:update / resource:update

### DIFF
--- a/docs/platform-operations/security/02-access-control.md
+++ b/docs/platform-operations/security/02-access-control.md
@@ -337,6 +337,7 @@ Massdriver defines 34 permissions using an `entity:verb` format.
 | `repo:push` | Publish new bundle versions |
 | `repo:create` | Create a new (empty) OCI repository |
 | `repo:update` | Modify a repository's user-settable metadata (e.g. attributes) |
+| `repo:grant` | Author or revoke grants sharing this repo with recipient projects. Distinct from `repo:update` (metadata) and `repo:pull` (downloading bundle contents). |
 | `repo:delete` | Remove an OCI repository (only when no versions are published) |
 
 ### Resource
@@ -347,6 +348,7 @@ Massdriver defines 34 permissions using an `entity:verb` format.
 | `resource:export` | Download credential payloads — IAM roles, connection strings, certificates |
 | `resource:import` | Import external cloud resources into Massdriver |
 | `resource:update` | Update an imported resource |
+| `resource:grant` | Author or revoke grants sharing this resource with recipient environments. Distinct from `resource:update` (metadata) and `resource:export` (downloading the unmasked payload). |
 | `resource:delete` | Delete a resource |
 
 ### Resource Type
@@ -581,9 +583,9 @@ Grant mutations are gated by edit access on the source:
 
 | Mutation | Authorization |
 |---|---|
-| `createRepoGrant` | `repo:update` on the source repo |
-| `createResourceGrant` | `resource:update` on the source resource |
-| `deleteGrant` | `repo:update` (repo-source grant) or `resource:update` (resource-source grant) |
+| `createRepoGrant` | `repo:grant` on the source repo |
+| `createResourceGrant` | `resource:grant` on the source resource |
+| `deleteGrant` | `repo:grant` (repo-source grant) or `resource:grant` (resource-source grant) |
 
 Grants are immutable: to change `recipient_conditions` or `action`, delete and
 re-create. There is no `updateGrant`.

--- a/docs/platform-operations/security/03-graphql-permissions.md
+++ b/docs/platform-operations/security/03-graphql-permissions.md
@@ -126,9 +126,9 @@ Deployments are an action *on* an instance — `createDeployment`, `proposeDeplo
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `createRepoGrant` | Mutation | `repo:update` | On the source repo. |
-| `createResourceGrant` | Mutation | `resource:update` | On the source resource. |
-| `deleteGrant` | Mutation | `repo:update` *or* `resource:update` | Dispatch on grant kind: `repo:update` for repo-source grants, `resource:update` for resource-source grants. |
+| `createRepoGrant` | Mutation | `repo:grant` | On the source repo. |
+| `createResourceGrant` | Mutation | `resource:grant` | On the source resource. |
+| `deleteGrant` | Mutation | `repo:grant` *or* `resource:grant` | Dispatch on grant kind: `repo:grant` for repo-source grants, `resource:grant` for resource-source grants. |
 
 There is no `updateGrant` — grants are immutable; delete and re-create to change `recipient_conditions` or `action`.
 


### PR DESCRIPTION
## Summary

Mirrors the platform-side ABAC catalog change in massdriver-cloud/massdriver#3202, which adds dedicated `repo:grant` and `resource:grant` permissions for grant authoring/revocation. `repo:update` and `resource:update` keep gating actual metadata edits (`updateOciRepo`, `updateResource`, narrowed-attributes-schema); only the grant-authoring paths moved to the new actions.

This is the inverse pattern of #187 (collapsing `instance:approve` into `instance:deploy`) — same surgical-table-edit shape, opposite direction.

## Changes

- `docs/platform-operations/security/02-access-control.md`
  - Add `repo:grant` and `resource:grant` rows to the repo and resource permission catalogs, slotted between `*:update` and `*:delete`.
  - Update the grants-authoring table so `createRepoGrant` / `createResourceGrant` / `deleteGrant` gate on `repo:grant` / `resource:grant`.
- `docs/platform-operations/security/03-graphql-permissions.md`
  - Same gate change for the Grant mutation table.
  - `updateResource` / `updateOciRepo` rows untouched — they remain `*:update` (metadata edits, not grant authoring).

## Test plan

- [ ] Verify the `*:grant` rows render in the rebuilt catalog tables.
- [ ] Spot-check that the Grant mutation table on the GraphQL permissions page now reads `repo:grant` / `resource:grant`.
- [ ] Confirm `updateOciRepo` and `updateResource` still show `*:update` (those are correct).