### PR TITLE
Operator guides: document id/md_metadata, connection & artifact shape, sensitive masking

### DIFF
--- a/docs/guides/operator-guides.md
+++ b/docs/guides/operator-guides.md
@@ -11,7 +11,7 @@ Operator guides (also called runbooks) provide operational documentation for you
 
 **Key features:**
 - **Dynamic content**: Variables are interpolated at render time with actual deployed values
-- **Context-aware**: Shows configuration, connections, and resource outputs specific to this instance
+- **Context-aware**: Shows configuration, dependencies, and resource outputs specific to this instance
 - **Operational focus**: Command examples, troubleshooting steps, and reference information
 - **Customizable**: You control the content—this is your documentation
 
@@ -54,11 +54,13 @@ Operator guides have access to the following top-level variables:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `{{id}}` | Instance identifier | `myapp-prod-useast1` |
-| `{{slug}}` | **Deprecated** alias for `id` (will be removed 2026-03-12) | `myapp-prod-useast1` |
 | `{{params.<field>}}` | Configuration parameter values | `{{params.database_name}}` |
 | `{{params.md_metadata.<field>}}` | Massdriver-injected metadata (see below) | `{{params.md_metadata.name_prefix}}` |
-| `{{connections.<name>.<...>}}` | Connected resource payload (shape depends on artifact schema) | `{{connections.network.specs.aws.region}}` |
-| `{{artifacts.<name>.<...>}}` | This bundle's output payload (shape depends on artifact definition) | `{{artifacts.database.data.infrastructure.arn}}` |
+| `{{dependencies.<name>.<...>}}` | Upstream dependency payload (shape depends on its resource type) | `{{dependencies.network.specs.aws.region}}` |
+| `{{resources.<name>.<...>}}` | This bundle's output payload (shape depends on its resource type) | `{{resources.database.data.infrastructure.arn}}` |
+| `{{slug}}` | **Deprecated** alias for `id` (will be removed 2026-03-12) | `myapp-prod-useast1` |
+| `{{connections.<name>.<...>}}` | **Deprecated** alias for `dependencies` (will be removed 2026-05-07) | `{{connections.network.specs.aws.region}}` |
+| `{{artifacts.<name>.<...>}}` | **Deprecated** alias for `resources` (will be removed 2026-05-07) | `{{artifacts.database.data.infrastructure.arn}}` |
 
 ### `params.md_metadata`
 
@@ -79,21 +81,25 @@ Massdriver injects a `md_metadata` block into `params` with deployment context:
 | `params.md_metadata.package.previous_status` | Status of the package before this deployment |
 | `params.md_metadata.target.contact_email` | Contact email of the user/service account that triggered the deployment |
 
-### Connections and Artifacts
+### Dependencies and Resources
 
-The shape of `connections.<name>` and `artifacts.<name>` is determined by the **artifact definition schema** they conform to. Massdriver's V1 artifact definitions typically split fields into two top-level keys:
+The shape of `dependencies.<name>` and `resources.<name>` is determined by the **resource type schema** they conform to. Massdriver's V1 artifact definitions typically split fields into two top-level keys:
 
 - **`specs`** — public metadata (regions, names, configuration)
 - **`data`** — connection details (ARNs, hostnames, credentials)
 
-So an AWS Lambda connection might expose `{{connections.my_lambda.specs.aws.region}}` and `{{connections.my_lambda.data.infrastructure.arn}}`. V2 resource-type schemas may use a flatter shape — always inspect the artifact definition (or `bundle.json` `connections_schema`) to see the exact field layout.
+So an AWS Lambda dependency might expose `{{dependencies.my_lambda.specs.aws.region}}` and `{{dependencies.my_lambda.data.infrastructure.arn}}`. V2 resource-type schemas may use a flatter shape — always inspect the resource type (or `bundle.json` `connections_schema`) to see the exact field layout.
+
+:::note Renamed from `connections` / `artifacts`
+`connections` and `artifacts` were renamed to `dependencies` and `resources` on 2026-05-07. The old names still work as aliases but will be removed — update your `operator.md` files to the new names.
+:::
 
 ### Sensitive field masking
 
-Fields marked `$md.sensitive: true` in the artifact's schema are **masked** to `[SENSITIVE]` rather than removed. The shape of the value is preserved (a sensitive object becomes an object with each leaf replaced; a sensitive array becomes a list of `[SENSITIVE]` strings). For example:
+Fields marked `$md.sensitive: true` in the resource type schema are **masked** to `[SENSITIVE]` rather than removed. The shape of the value is preserved (a sensitive object becomes an object with each leaf replaced; a sensitive array becomes a list of `[SENSITIVE]` strings). For example:
 
 ```mustache
-Password: {{connections.my_db.data.authentication.password}}
+Password: {{dependencies.my_db.data.authentication.password}}
 ```
 
 Renders as:
@@ -127,14 +133,14 @@ Version: {{params.version}}
 Check if a value exists:
 
 ```mustache
-{{#connections.database}}
+{{#dependencies.database}}
 **Database Connected:** Yes
 **Hostname:** {{data.infrastructure.hostname}}
-{{/connections.database}}
+{{/dependencies.database}}
 
-{{^connections.database}}
+{{^dependencies.database}}
 _No database connected_
-{{/connections.database}}
+{{/dependencies.database}}
 ```
 
 `{{#name}}` — Renders if truthy
@@ -193,21 +199,21 @@ templating: mustache
 - **App name:** `{{params.app_name}}`
 - **Version:** `{{params.version}}`
 
-## Connections
+## Dependencies
 
-{{#connections.network}}
+{{#dependencies.network}}
 - **VPC region:** `{{specs.aws.region}}`
 - **VPC ID:** `{{data.infrastructure.arn}}`
-{{/connections.network}}
+{{/dependencies.network}}
 
-{{^connections.network}}
-_No network connection wired up._
-{{/connections.network}}
+{{^dependencies.network}}
+_No network dependency wired up._
+{{/dependencies.network}}
 
-## Outputs (this bundle)
+## Resources (this bundle's outputs)
 
-- **API endpoint:** `https://{{artifacts.api.specs.hostname}}`
-- **Lambda ARN:** `{{artifacts.fn.data.infrastructure.arn}}`
+- **API endpoint:** `https://{{resources.api.specs.hostname}}`
+- **Lambda ARN:** `{{resources.fn.data.infrastructure.arn}}`
 
 ## Operational Commands
 
@@ -238,7 +244,7 @@ Contact for this environment: `{{params.md_metadata.target.contact_email}}`
 **Don't:**
 - Print sensitive fields — they render as `[SENSITIVE]`
 - Use placeholders like `<replace-me>` when you can interpolate
-- Rely on `{{slug}}` in new guides — use `{{id}}` (slug is deprecated and will be removed)
+- Rely on the deprecated names `{{slug}}`, `{{connections.*}}`, or `{{artifacts.*}}` in new guides — use `{{id}}`, `{{dependencies.*}}`, and `{{resources.*}}`
 - Forget to update the guide when you change schemas
 
 ## Testing Your Guide

--- a/docs/guides/operator-guides.md
+++ b/docs/guides/operator-guides.md
@@ -45,22 +45,70 @@ templating: liquid
 
 More powerful templating with filters and complex logic. Use when you need advanced string manipulation or conditional logic.
 
+If frontmatter is missing or `templating` is unset (or set to an unsupported value), the guide is rendered as-is with no interpolation.
+
 ## Available Context
 
-Operator guides have access to the following data:
+Operator guides have access to the following top-level variables:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `{{slug}}` | Instance slug (unique identifier) | `myapp-prod-useast1` |
-| `{{params.field}}` | Configuration parameter values | `{{params.database_name}}` |
-| `{{connections.name.specs.field}}` | Connected resource specs (public metadata) | `{{connections.network.specs.cidr}}` |
-| `{{artifacts.name.specs.field}}` | This bundle's output resource specs (template key remains `artifacts`) | `{{artifacts.database.specs.hostname}}` |
+| `{{id}}` | Instance identifier | `myapp-prod-useast1` |
+| `{{slug}}` | **Deprecated** alias for `id` (will be removed 2026-03-12) | `myapp-prod-useast1` |
+| `{{params.<field>}}` | Configuration parameter values | `{{params.database_name}}` |
+| `{{params.md_metadata.<field>}}` | Massdriver-injected metadata (see below) | `{{params.md_metadata.name_prefix}}` |
+| `{{connections.<name>.<...>}}` | Connected resource payload (shape depends on artifact schema) | `{{connections.network.specs.aws.region}}` |
+| `{{artifacts.<name>.<...>}}` | This bundle's output payload (shape depends on artifact definition) | `{{artifacts.database.data.infrastructure.arn}}` |
 
-**Important notes:**
-- Resource `data` fields (encrypted secrets/credentials) are **not accessible** in operator guides
-- Only `specs` (public metadata) are available
-- Connection names match what you defined in `massdriver.yaml`
-- The template key under `artifacts.<name>` matches the resources this bundle produces (declared under the `artifacts:` block in `massdriver.yaml`)
+### `params.md_metadata`
+
+Massdriver injects a `md_metadata` block into `params` with deployment context:
+
+| Field | Description |
+|-------|-------------|
+| `params.md_metadata.name_prefix` | Resource name prefix for this package (e.g., `prod-us-west-myapp-abc123`) |
+| `params.md_metadata.default_tags.managed-by` | Always `massdriver` |
+| `params.md_metadata.default_tags.md-project` | Project identifier |
+| `params.md_metadata.default_tags.md-target` | Target/environment identifier |
+| `params.md_metadata.default_tags.md-manifest` | Manifest identifier |
+| `params.md_metadata.default_tags.md-package` | Package name prefix |
+| `params.md_metadata.observability.alarm_webhook_url` | Webhook URL for forwarding alarms to Massdriver |
+| `params.md_metadata.package.created_at` | When the package was created |
+| `params.md_metadata.package.updated_at` | When the package was last updated |
+| `params.md_metadata.package.deployment_enqueued_at` | When the current deployment was enqueued |
+| `params.md_metadata.package.previous_status` | Status of the package before this deployment |
+| `params.md_metadata.target.contact_email` | Contact email of the user/service account that triggered the deployment |
+
+### Connections and Artifacts
+
+The shape of `connections.<name>` and `artifacts.<name>` is determined by the **artifact definition schema** they conform to. Massdriver's V1 artifact definitions typically split fields into two top-level keys:
+
+- **`specs`** — public metadata (regions, names, configuration)
+- **`data`** — connection details (ARNs, hostnames, credentials)
+
+So an AWS Lambda connection might expose `{{connections.my_lambda.specs.aws.region}}` and `{{connections.my_lambda.data.infrastructure.arn}}`. V2 resource-type schemas may use a flatter shape — always inspect the artifact definition (or `bundle.json` `connections_schema`) to see the exact field layout.
+
+### Sensitive field masking
+
+Fields marked `$md.sensitive: true` in the artifact's schema are **masked** to `[SENSITIVE]` rather than removed. The shape of the value is preserved (a sensitive object becomes an object with each leaf replaced; a sensitive array becomes a list of `[SENSITIVE]` strings). For example:
+
+```mustache
+Password: {{connections.my_db.data.authentication.password}}
+```
+
+Renders as:
+
+```
+Password: [SENSITIVE]
+```
+
+This means:
+- **Don't print credentials** in the rendered guide — the literal `[SENSITIVE]` text is not useful to operators.
+- **Do print non-sensitive metadata** like ARNs, regions, hostnames, and ports freely.
+
+### Missing keys
+
+Both engines render missing keys as empty strings rather than errors, so it's safe to reference fields that may not always be present.
 
 ## Mustache Syntax Reference
 
@@ -69,7 +117,7 @@ Operator guides have access to the following data:
 Display a value:
 
 ```mustache
-Instance: {{slug}}
+Instance: {{id}}
 Database: {{params.database_name}}
 Version: {{params.version}}
 ```
@@ -81,7 +129,7 @@ Check if a value exists:
 ```mustache
 {{#connections.database}}
 **Database Connected:** Yes
-**Hostname:** {{specs.hostname}}
+**Hostname:** {{data.infrastructure.hostname}}
 {{/connections.database}}
 
 {{^connections.database}}
@@ -89,8 +137,8 @@ _No database connected_
 {{/connections.database}}
 ```
 
-`{{#name}}` - Renders if truthy
-`{{^name}}` - Renders if falsy (inverse)
+`{{#name}}` — Renders if truthy
+`{{^name}}` — Renders if falsy (inverse)
 
 ### Loops
 
@@ -111,82 +159,87 @@ Add non-rendered notes:
 {{! This is a comment and won't appear in the rendered guide }}
 ```
 
-## Example Operator Guide Structure
+## Liquid Syntax Reference
 
-Here's a practical template structure:
+Liquid supports `{% if %}`, filters, and richer expressions. Example:
+
+```liquid
+{% if params.enable_ssl %}
+SSL is enabled on port {{ params.ssl_port }}
+{% else %}
+SSL is not enabled
+{% endif %}
+
+Deployed in: {{ params.md_metadata.default_tags.md-target | upcase }}
+```
+
+See the [Liquid documentation](https://shopify.github.io/liquid/) for the full filter and tag reference.
+
+## Example Operator Guide
 
 ```markdown
 ---
 templating: mustache
 ---
 
-# My Bundle Runbook
+# {{params.md_metadata.default_tags.md-package}} Runbook
 
-> **Templating**: This runbook supports mustache templating.
-> **Available context**: `slug`, `params`, `connections.<name>.specs`, `artifacts.<name>.specs`
+> **Instance:** `{{id}}`
+> **Project / Target:** `{{params.md_metadata.default_tags.md-project}}` / `{{params.md_metadata.default_tags.md-target}}`
+> **Deployment enqueued:** {{params.md_metadata.package.deployment_enqueued_at}}
 
-## Instance Information
+## Configuration
 
-**Slug:** `{{slug}}`
+- **App name:** `{{params.app_name}}`
+- **Version:** `{{params.version}}`
 
-### Configuration
+## Connections
 
-**Parameter Name:** `{{params.parameter_name}}`
-**Another Parameter:** `{{params.another_param}}`
+{{#connections.network}}
+- **VPC region:** `{{specs.aws.region}}`
+- **VPC ID:** `{{data.infrastructure.arn}}`
+{{/connections.network}}
 
-### Connections
+{{^connections.network}}
+_No network connection wired up._
+{{/connections.network}}
 
-{{#connections.dependency}}
-**Connected to:** {{specs.some_field}}
-**Region:** {{specs.region}}
-{{/connections.dependency}}
+## Outputs (this bundle)
 
-{{^connections.dependency}}
-_No dependency connected_
-{{/connections.dependency}}
-
----
+- **API endpoint:** `https://{{artifacts.api.specs.hostname}}`
+- **Lambda ARN:** `{{artifacts.fn.data.infrastructure.arn}}`
 
 ## Operational Commands
 
-**Example command using config:**
-
 \`\`\`bash
-some-cli --name {{params.name}} --version {{params.version}}
+# Tail logs (replace LOG_GROUP if needed)
+aws logs tail /aws/lambda/{{params.md_metadata.name_prefix}} --follow
+
+# Re-deploy via Massdriver
+mass instance deploy {{id}}
 \`\`\`
 
-**Example using resource outputs:**
+## Alarms
 
-\`\`\`bash
-curl https://{{artifacts.api.specs.hostname}}/health
-\`\`\`
+This package forwards alarms to: `{{params.md_metadata.observability.alarm_webhook_url}}`
 
-**Example using connection specs:**
-
-\`\`\`bash
-ping {{connections.network.specs.gateway_ip}}
-\`\`\`
-
----
-
-**Ready to customize?** [Edit this runbook](https://github.com/YOUR_ORG/massdriver-catalog/tree/main/bundles/your-bundle/operator.md) 🎯
+Contact for this environment: `{{params.md_metadata.target.contact_email}}`
 ```
 
 ## Writing Effective Operator Guides
 
 **Do:**
-- Use actual parameter/connection/resource field names from your schemas
+- Use actual parameter, connection, and artifact field names from your schemas
 - Provide copy-paste-ready commands with interpolated values
 - Show common operations (connecting, testing, troubleshooting)
-- Keep it concise—operators skim these under pressure
+- Keep it concise — operators skim these under pressure
 - Test interpolation by deploying and checking the rendered guide
 
 **Don't:**
-- Reference `data` fields (they're not accessible)
+- Print sensitive fields — they render as `[SENSITIVE]`
 - Use placeholders like `<replace-me>` when you can interpolate
-- Write novels—keep it scannable
-- Forget to update when you change schemas
-- Include sensitive information in plain text
+- Rely on `{{slug}}` in new guides — use `{{id}}` (slug is deprecated and will be removed)
+- Forget to update the guide when you change schemas
 
 ## Testing Your Guide
 
@@ -194,17 +247,11 @@ ping {{connections.network.specs.gateway_ip}}
 2. Open the instance in Massdriver UI
 3. Check the "Runbook" tab
 4. Verify all `{{variables}}` interpolated correctly
-5. Fix any missing fields or typos
+5. Fix any missing fields, typos, or sensitive-field references
 
 ## Further Reading
 
 - [Mustache Manual](https://mustache.github.io/mustache.5.html)
 - [Liquid Documentation](https://shopify.github.io/liquid/)
-- [Massdriver Documentation](https://docs.massdriver.cloud)
 - [Bundle Structure](../concepts/bundles)
 - [Creating Bundles Guide](../getting_started/03-creating-bundles.md)
-
----
-
-**Customize this template for your bundle's specific operational needs.**
-


### PR DESCRIPTION
## Summary
- Update `docs/guides/operator-guides.md` to match the current operator-guide rendering pipeline in [`Massdriver.Platform.OperatorGuideRenderer`](https://github.com/massdriver-cloud/massdriver/blob/main/lib/massdriver/platform/operator_guide_renderer.ex) and [`Platform.prepare_operator_guide_context/2`](https://github.com/massdriver-cloud/massdriver/blob/main/lib/massdriver/platform/platform.ex).
- Add `{{id}}` as the new top-level identifier and mark `{{slug}}` as deprecated (sunset 2026-03-12, per the comment in `prepare_operator_guide_context/2`).
- Document the `params.md_metadata.*` block injected by `Provisioning.build_md_metadata/2` (`name_prefix`, `default_tags.*`, `observability.alarm_webhook_url`, `package.{created_at,updated_at,deployment_enqueued_at,previous_status}`, `target.contact_email`).
- Correct the connection/artifact section: payload shape is determined by the artifact definition schema (V1 typically has `data`/`specs`, V2 may be flatter) — the previous docs assumed an implicit `.specs` wrapper that doesn't exist in the renderer.
- Document sensitive masking: `$md.sensitive: true` fields render as `[SENSITIVE]` while preserving the value's shape, rather than being removed.
- Replace the runbook example with one that exercises `md_metadata`, connections, and artifacts against realistic V1 `data`/`specs` paths.

## Test plan
- [ ] `yarn start` (or `make dev`) and load `/guides/operator-guides` — verify rendering and table layout
- [ ] Spot-check links to Bundle Structure and Creating Bundles still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)