### PR TITLE
Fix 10-deployments page: add to sidebar, fix Mermaid lexer error

### DIFF
--- a/docs/concepts/10-deployments.md
+++ b/docs/concepts/10-deployments.md
@@ -92,7 +92,7 @@ Every instance has its own queue. Only one deployment per instance can be `RUNNI
 
 ```mermaid
 flowchart TB
-    subgraph Q[Instance queue — drains in creation order]
+    subgraph Q ["Instance queue — drains in creation order"]
         direction LR
         R[RUNNING]
         P1[PENDING]

--- a/sidebars.js
+++ b/sidebars.js
@@ -107,6 +107,7 @@ module.exports = {
         "concepts/concepts-resources-and-types",
         "concepts/concepts-projects-and-environments",
         "concepts/concepts-components-instances-deployments",
+        "concepts/concepts-deployments",
         "concepts/concepts-connections",
         "concepts/concepts-organizations",
       ],


### PR DESCRIPTION
## Summary
- Add `concepts/concepts-deployments` to the Concepts category in `sidebars.js` so the new Deployments page actually appears in the sidebar.
- Quote the subgraph title in the per-instance queue Mermaid diagram. The em-dash inside the bracket-form `subgraph Q[Instance queue — drains in creation order]` was tripping Mermaid's lexer (`Lexical error on line 2. Unrecognized text...`) and crashing the page. Switching to `subgraph Q ["..."]` parses cleanly.

## Test plan
- [ ] `yarn start` and confirm "Deployments" appears under Concepts in the sidebar
- [ ] Navigate to `/concepts/deployments` and confirm the page renders without the Mermaid lexer error
- [ ] Confirm the "Instance queue — drains in creation order" diagram renders with all four queue nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)