### PR TITLE
Link to massdriver-cloud/actions repo and example workflows

### DIFF
--- a/docs/platform-operations/ci-cd/01-github.md
+++ b/docs/platform-operations/ci-cd/01-github.md
@@ -9,6 +9,12 @@ sidebar_label: GitHub Action
 
 This guide will walk you through the process of setting up a GitHub Action to build, push, and deploy app changes to your chosen cloud container repository.
 
+:::tip Source and ready-to-fork workflows
+
+The actions are open source at [`massdriver-cloud/actions`](https://github.com/massdriver-cloud/actions). Drop-in starter workflows for bundle publishing, image build + deploy, and GitOps-style deploys live in [`example_workflows/`](https://github.com/massdriver-cloud/actions/tree/main/example_workflows).
+
+:::
+
 :::note
 
 Before getting started, you'll need:
@@ -177,7 +183,7 @@ Then your image tag path would be `.runtime.image.tag`.
 * If your `Dockerfile` is in a subdirectory, you can update the `build-context` to point to that directory. For example, if your `Dockerfile` is in the `./app` directory, you can set the `build-context` to `./app`.
 * If your `massdriver.yaml` file is in a subdirectory, you can update the `build-directory` to point to that directory. For example, if your `massdriver.yaml` file is in the `./app/massdriver` directory, you can set the `build-directory` to `./app/massdriver`.
 
-View the Massdriver GitHub Actions on the [GitHub Marketplace](https://github.com/marketplace/actions/massdriver-actions).
+View the Massdriver GitHub Actions on the [GitHub Marketplace](https://github.com/marketplace/actions/massdriver-actions), browse the source at [`massdriver-cloud/actions`](https://github.com/massdriver-cloud/actions), or copy a starter from [`example_workflows/`](https://github.com/massdriver-cloud/actions/tree/main/example_workflows).
 
 ## Per-PR Preview Environments
 


### PR DESCRIPTION
## Summary
- Add a tip callout at the top of the CI/CD GitHub Action page pointing to the [`massdriver-cloud/actions`](https://github.com/massdriver-cloud/actions) repo and its [`example_workflows/`](https://github.com/massdriver-cloud/actions/tree/main/example_workflows) directory (md_bundle_publish, md_gitops_deploy, md_image_build_and_deploy, md_publish_and_deploy).
- Expand the existing GitHub Marketplace footer line on the same page to also link the source repo and `example_workflows/`.

## Test plan
- [ ] Verify the new tip callout renders correctly on the GitHub Action docs page.
- [ ] Verify all three external links (repo, `example_workflows/`, Marketplace) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)