### PR TITLE
docs(abac): organization:manage split + drop is_org_admin bypass (#3238)

### DIFF
--- a/docs/platform-operations/security/02-access-control.md
+++ b/docs/platform-operations/security/02-access-control.md
@@ -212,7 +212,8 @@ For per-repo or per-resource sharing — making a specific OCI repo or resource 
 - **Partial matches never accumulate** — you cannot combine conditions from different policies
 - **Deny wins** — if any deny policy matches, access is denied regardless of allow policies
 - **Implicit deny** — if no policy matches, access is denied
-- **Org admin bypass** — the organization owner account and any group with the `organization:manage` action skip all access control checks
+- **Built-in admin group is privileged by policy, not by code** — the built-in `organization.admin` group carries one seeded `allow` policy per catalog action with `conditions: nil`, so its members satisfy every check through the normal evaluation path. No bypass, no special case in the engine. Policies on the built-in admin and viewer groups cannot be created, updated, deleted, or renamed — their policy set is fixed.
+- **`organization:manage` is a one-level umbrella** — a policy whose `actions` includes `organization:manage` satisfies any `organization:manage*` sub-action query. Author a single allow policy on a custom group to grant full org-level administrative authority without putting members in the built-in admin group. The umbrella does not widen any other namespace, and holding a single sub-action does **not** imply the umbrella.
 - **Empty conditions are invalid** — use `*` for wildcard
 
 ### Multi-Action Policies and Scope Filtering
@@ -275,6 +276,7 @@ Use this table to avoid relying on `md-id` wildcards (`md-id: [api-prod-*]`). Sy
 | group           | `md-id`                                                          | (none — groups are principals, not scoped entities) |
 | repo            | `md-id`, `md-repo`                                               | `:repo`                                        |
 | resource_type   | `md-id`                                                          | (none today)                                   |
+| organization    | `md-id`                                                          | (none — no `:organization` custom-attribute scope) |
 
 **Cascade**: a custom attribute registered at scope `:project` is reachable on every descendant — environment, component, instance, resource — because the project's value flows down. Setting `team: payments` at the project level means every instance in that project carries `team=payments` for policy matching, even though the value isn't physically stored on each instance row.
 
@@ -288,7 +290,7 @@ Use this table to avoid relying on `md-id` wildcards (`md-id: [api-prod-*]`). Sy
 
 ## Permissions
 
-Massdriver defines 34 permissions using an `entity:verb` format.
+Massdriver defines 39 permissions using an `entity:verb` format.
 
 ### Project
 
@@ -353,16 +355,26 @@ Massdriver defines 34 permissions using an `entity:verb` format.
 
 ### Resource Type
 
-Resource types are organization-level catalog metadata. Listing and viewing resource types is gated by `organization:view`. Publishing (`publishResourceType`) and deleting (`deleteResourceType`) require `organization:manage`.
+Resource types are organization-level catalog metadata. Listing and viewing resource types is open to every org member. Publishing (`publishResourceType`) and deleting (`deleteResourceType`) require `organization:manageResourceTypes` (covered by the `organization:manage` umbrella).
 
 Resource types push `md-resource-type` onto every resource produced from them, so policies can target by type (`md-resource-type: [aws-iam-role]`). User-settable resource-type attributes will arrive when resource types move to OCI-hosted distribution.
 
 ### Organization
 
+Organization-level capabilities are split into one umbrella action and seven sub-actions. Authoring a single policy with `organization:manage` covers every sub-action via the engine's umbrella rule; authoring an individual sub-action grants only that capability.
+
 | Permission | Description |
 |---|---|
-| `organization:view` | Load the organization's public profile (name, logo, identifier). Granted implicitly to every member through their group memberships. |
-| `organization:manage` | Update organization-level settings — display name, logo, members, billing (subscription, payment, seats, Stripe customer portal), and the custom attribute schema that governs every project, environment, and resource. Required to view the member roster as a single list. |
+| `organization:manage` | Umbrella. A policy granting `organization:manage` satisfies any of the seven `organization:manage*` sub-actions below. |
+| `organization:manageServiceAccounts` | Create, update, delete, list, and inspect service accounts. |
+| `organization:manageGroups` | Create new groups. Editing an existing group's membership or policies is gated separately by `group:manage` on that group. |
+| `organization:manageBilling` | View and change subscription, payment, seats, and Stripe customer portal. |
+| `organization:manageIntegrations` | Configure, enable, disable, and delete third-party integrations (cost reports, metrics, etc.). |
+| `organization:manageCustomAttributes` | Declare, update, and delete custom attributes — the org-wide schema that governs user-defined attributes on projects, environments, components, and resources. |
+| `organization:manageResourceTypes` | Publish and delete resource types — the org-level catalog of schemas describing each kind of infrastructure output. |
+| `organization:manageProfile` | Update display name and logo, remove members, and view the member roster as a single list. |
+
+Reading the organization's public profile (name, logo, identifier) is open to every org member — no policy required.
 
 ---
 
@@ -874,7 +886,7 @@ Because permissions are attribute-based rather than ID-based, authorization surv
 
 ## Built-in Administration
 
-The organization owner account always bypasses access control checks. The built-in `organization.admin` group also bypasses all access control checks in that organization. Use sparingly — limit to the small number of people who own the account itself.
+The organization owner account always bypasses access control checks. The built-in `organization.admin` group is privileged by data, not by code — it carries one seeded `allow` policy per catalog action with `conditions: nil`, so its members satisfy every check through the normal evaluation path. Policies on the built-in admin and viewer groups cannot be created, updated, deleted, or renamed. Use sparingly — limit membership to the small number of people who own the account itself.
 
 ## Related
 

--- a/docs/platform-operations/security/02-access-control.md
+++ b/docs/platform-operations/security/02-access-control.md
@@ -212,8 +212,8 @@ For per-repo or per-resource sharing — making a specific OCI repo or resource 
 - **Partial matches never accumulate** — you cannot combine conditions from different policies
 - **Deny wins** — if any deny policy matches, access is denied regardless of allow policies
 - **Implicit deny** — if no policy matches, access is denied
-- **Built-in admin group is privileged by policy, not by code** — the built-in `organization.admin` group carries one seeded `allow` policy per catalog action with `conditions: nil`, so its members satisfy every check through the normal evaluation path. No bypass, no special case in the engine. Policies on the built-in admin and viewer groups cannot be created, updated, deleted, or renamed — their policy set is fixed.
-- **`organization:manage` is a one-level umbrella** — a policy whose `actions` includes `organization:manage` satisfies any `organization:manage*` sub-action query. Author a single allow policy on a custom group to grant full org-level administrative authority without putting members in the built-in admin group. The umbrella does not widen any other namespace, and holding a single sub-action does **not** imply the umbrella.
+- **Built-in admin group has full access** — the built-in `organization.admin` group grants its members access to every action in the org. The built-in admin and viewer groups are fixed — you can't author policies on them, rename them, or delete them. Use a custom group for everything else.
+- **`organization:manage` is a one-level umbrella** — a policy whose `actions` includes `organization:manage` satisfies any `organization:manage*` sub-action query. Author it once on a custom group to grant full org-level administrative access without putting people in the built-in admin group. The umbrella does not widen any other namespace, and holding a single sub-action does **not** imply the umbrella.
 - **Empty conditions are invalid** — use `*` for wildcard
 
 ### Multi-Action Policies and Scope Filtering
@@ -276,7 +276,6 @@ Use this table to avoid relying on `md-id` wildcards (`md-id: [api-prod-*]`). Sy
 | group           | `md-id`                                                          | (none — groups are principals, not scoped entities) |
 | repo            | `md-id`, `md-repo`                                               | `:repo`                                        |
 | resource_type   | `md-id`                                                          | (none today)                                   |
-| organization    | `md-id`                                                          | (none — no `:organization` custom-attribute scope) |
 
 **Cascade**: a custom attribute registered at scope `:project` is reachable on every descendant — environment, component, instance, resource — because the project's value flows down. Setting `team: payments` at the project level means every instance in that project carries `team=payments` for policy matching, even though the value isn't physically stored on each instance row.
 
@@ -886,7 +885,7 @@ Because permissions are attribute-based rather than ID-based, authorization surv
 
 ## Built-in Administration
 
-The organization owner account always bypasses access control checks. The built-in `organization.admin` group is privileged by data, not by code — it carries one seeded `allow` policy per catalog action with `conditions: nil`, so its members satisfy every check through the normal evaluation path. Policies on the built-in admin and viewer groups cannot be created, updated, deleted, or renamed. Use sparingly — limit membership to the small number of people who own the account itself.
+The organization owner account always bypasses access control checks. The built-in `organization.admin` group has full access to everything in the org. The built-in admin and viewer groups are fixed — you can't author policies on them, rename them, or delete them. Use a custom group for everything else, and limit admin membership to the small number of people who own the account itself.
 
 ## Related
 

--- a/docs/platform-operations/security/03-graphql-permissions.md
+++ b/docs/platform-operations/security/03-graphql-permissions.md
@@ -18,6 +18,8 @@ This page maps every operation in the Massdriver GraphQL API to the [ABAC permis
 
 If you're building a least-privilege policy, scan the table for the operations the principal needs and assemble the union of required permissions. List queries (`projects`, `instances`, `resources`, etc.) are visibility-filtered: a caller only sees what their group policies and grants make visible — there's no explicit list permission to grant.
 
+`organization:manage` is a one-level umbrella: a single policy granting `organization:manage` on a custom group satisfies any `organization:manageServiceAccounts`, `organization:manageGroups`, `organization:manageBilling`, `organization:manageIntegrations`, `organization:manageCustomAttributes`, `organization:manageResourceTypes`, or `organization:manageProfile` query below. Grant the umbrella when you want full org-level administrative authority on a custom group; grant a single sub-action when you want to scope authority to one capability.
+
 ---
 
 ## Project
@@ -110,8 +112,8 @@ Deployments are an action *on* an instance — `createDeployment`, `planDeployme
 |---|---|---|---|
 | `resourceTypes` | Query | *no explicit gate* | Available to any authenticated member. |
 | `resourceType` | Query | *no explicit gate* | |
-| `publishResourceType` | Mutation | `organization:manage` | Deprecated bridge from V0 `publishArtifactDefinition`. Dedicated resource type permissions are coming when resource types move to OCI-hosted distribution. |
-| `deleteResourceType` | Mutation | `organization:manage` | Deprecated bridge from V0 `deleteArtifactDefinition`. Dedicated resource type permissions are coming when resource types move to OCI-hosted distribution. |
+| `publishResourceType` | Mutation | `organization:manageResourceTypes` | Covered by the `organization:manage` umbrella. Deprecated bridge from V0 `publishArtifactDefinition`. |
+| `deleteResourceType` | Mutation | `organization:manageResourceTypes` | Covered by the `organization:manage` umbrella. Deprecated bridge from V0 `deleteArtifactDefinition`. |
 
 ## OCI Repo / Bundle
 
@@ -141,7 +143,7 @@ There is no `updateGrant` — grants are immutable; delete and re-create to chan
 |---|---|---|---|
 | `groups` | Query | *visibility-filtered* | |
 | `group` | Query | `group:view` | |
-| `createGroup` | Mutation | `organization:manage` | Org-level: only managers can create groups. |
+| `createGroup` | Mutation | `organization:manageGroups` | Covered by the `organization:manage` umbrella. Editing an existing group's membership or policies is gated separately by `group:manage` on that group. |
 | `updateGroup` | Mutation | `group:manage` | |
 | `deleteGroup` | Mutation | `group:manage` | |
 | `addAccountToGroup` | Mutation | `group:manage` | |
@@ -158,7 +160,7 @@ There is no `updateGrant` — grants are immutable; delete and re-create to chan
 | `policyActions` | Query | *no explicit gate* | Catalog of available actions. |
 | `evaluatePolicy` | Query | *no explicit gate* | Evaluation runs against the caller's own effective permissions. |
 | `evaluatePolicies` | Query | *no explicit gate* | Batched form of `evaluatePolicy`. |
-| `explainPolicy` | Query | `organization:view` | Renders a policy spec (same shape as `createGroupPolicy` input) as plain-English sentences. Does not require the policy to exist. |
+| `explainPolicy` | Query | *no explicit gate* | Renders a policy spec (same shape as `createGroupPolicy` input) as plain-English sentences. Open to every org member; does not require the policy to exist. |
 | `createGroupPolicy` | Mutation | `group:manage` | Policies attach to groups. |
 | `updatePolicy` | Mutation | `group:manage` | |
 | `deletePolicy` | Mutation | `group:manage` | |
@@ -169,57 +171,57 @@ There is no `updateGrant` — grants are immutable; delete and re-create to chan
 |---|---|---|---|
 | `customAttributeSchema` | Query | *no explicit gate* | Schema is org-public. |
 | `customAttributeValues` | Query | *no explicit gate* | |
-| `createCustomAttribute` | Mutation | `organization:manage` | |
-| `updateCustomAttribute` | Mutation | `organization:manage` | |
-| `deleteCustomAttribute` | Mutation | `organization:manage` | |
+| `createCustomAttribute` | Mutation | `organization:manageCustomAttributes` | Covered by the `organization:manage` umbrella. |
+| `updateCustomAttribute` | Mutation | `organization:manageCustomAttributes` | Covered by the `organization:manage` umbrella. |
+| `deleteCustomAttribute` | Mutation | `organization:manageCustomAttributes` | Covered by the `organization:manage` umbrella. |
 
 ## Organization
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `organization` | Query | `organization:view` | Public profile fields require only `organization:view` (granted implicitly to every member). Sensitive subfields (`members`, `billing`, `customAttributes`) require `organization:manage` and resolve to `null` with a top-level `FORBIDDEN` error otherwise. |
+| `organization` | Query | *no explicit gate* | Public profile fields (name, logo, identifier) are open to every org member. Sensitive subfields gate individually: `members` requires `organization:manageProfile`, `billing` requires `organization:manageBilling`, `customAttributes` requires `organization:manageCustomAttributes`. Each resolves to `null` with a top-level `FORBIDDEN` error when the caller lacks the sub-action. All three are covered by the `organization:manage` umbrella. |
 | `createOrganization` | Mutation | *authenticated only* | Caller becomes the org's first owner; no ABAC permission since the org doesn't exist yet. |
-| `updateOrganization` | Mutation | `organization:manage` | |
-| `setOrganizationLogo` | Mutation | `organization:manage` | |
-| `removeOrganizationLogo` | Mutation | `organization:manage` | |
-| `deleteOrganizationMember` | Mutation | `organization:manage` | |
+| `updateOrganization` | Mutation | `organization:manageProfile` | Covered by the `organization:manage` umbrella. |
+| `setOrganizationLogo` | Mutation | `organization:manageProfile` | Covered by the `organization:manage` umbrella. |
+| `removeOrganizationLogo` | Mutation | `organization:manageProfile` | Covered by the `organization:manage` umbrella. |
+| `deleteOrganizationMember` | Mutation | `organization:manageProfile` | Covered by the `organization:manage` umbrella. |
 
 ## Service Account
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `serviceAccounts` | Query | `organization:manage` | Service accounts are only listable by org managers. |
-| `serviceAccount` | Query | `organization:manage` | |
-| `createServiceAccount` | Mutation | `organization:manage` | |
-| `updateServiceAccount` | Mutation | `organization:manage` | |
-| `deleteServiceAccount` | Mutation | `organization:manage` | |
+| `serviceAccounts` | Query | `organization:manageServiceAccounts` | Covered by the `organization:manage` umbrella. |
+| `serviceAccount` | Query | `organization:manageServiceAccounts` | Covered by the `organization:manage` umbrella. |
+| `createServiceAccount` | Mutation | `organization:manageServiceAccounts` | Covered by the `organization:manage` umbrella. |
+| `updateServiceAccount` | Mutation | `organization:manageServiceAccounts` | Covered by the `organization:manage` umbrella. |
+| `deleteServiceAccount` | Mutation | `organization:manageServiceAccounts` | Covered by the `organization:manage` umbrella. |
 
 ## Access Token
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `accessTokens` | Query | `organization:view` | Only your own tokens — admins cannot list other principals' tokens. |
-| `createAccessToken` | Mutation | `organization:view` | Issues a token for the calling subject. |
+| `accessTokens` | Query | *no explicit gate* | Open to every org member; only returns your own tokens — admins cannot list other principals' tokens. |
+| `createAccessToken` | Mutation | *no explicit gate* | Open to every org member; issues a token for the calling subject. |
 | `revokeAccessToken` | Mutation | *owner-only* | Owner-scoped: only the token's owning subject can revoke; admins cannot revoke another user's personal tokens. |
 
 ## Integration
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `integrations` | Query | `organization:view` | |
-| `integration` | Query | `organization:view` | |
+| `integrations` | Query | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
+| `integration` | Query | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
 | `integrationTypes` | Query | *no explicit gate* | |
-| `createIntegration` | Mutation | `organization:manage` | |
-| `enableIntegration` | Mutation | `organization:manage` | |
-| `disableIntegration` | Mutation | `organization:manage` | |
-| `deleteIntegration` | Mutation | `organization:manage` | |
+| `createIntegration` | Mutation | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
+| `enableIntegration` | Mutation | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
+| `disableIntegration` | Mutation | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
+| `deleteIntegration` | Mutation | `organization:manageIntegrations` | Covered by the `organization:manage` umbrella. |
 
 ## Audit Log
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `auditLogs` | Query | `organization:view` | Returns only entries the caller is allowed to see — `organization:manage` widens the result set. |
-| `auditLog` | Query | `organization:view` | |
+| `auditLogs` | Query | *project-scoped rows: no explicit gate; org-level rows: `organization:manage`* | Project-scoped audit rows cascade from `project:view` — a caller sees the entries on every project they can view. Org-level rows (billing, integrations, service accounts, profile changes, etc.) are only included when the caller holds the `organization:manage` umbrella. |
+| `auditLog` | Query | *project-scoped: no explicit gate; org-level: `organization:manage`* | Same split as the list query. Project-scoped entries are reachable through `project:view` on the entry's project; org-level entries require the umbrella. |
 | `auditLogEventTypes` | Query | *no explicit gate* | Catalog query. |
 
 ## Event Catalog
@@ -232,7 +234,7 @@ There is no `updateGrant` — grants are immutable; delete and re-create to chan
 
 | Operation | Type | Required permission(s) | Notes |
 |---|---|---|---|
-| `organizationEvents` | Subscription | `organization:view` | |
+| `organizationEvents` | Subscription | *no explicit gate* | Open to every org member. |
 | `projectEvents` | Subscription | `project:view` | |
 | `environmentEvents` | Subscription | `project:view` | Inherits the surrounding project's view permission. |
 | `instanceEvents` | Subscription | `project:view` | |
@@ -270,7 +272,7 @@ The single-entity counterpart (`project`, `ociRepo`, `resource`) explicitly chec
 
 - **`forbidden` is masked as `not_found`** for read paths that need to obscure existence (e.g., `project`, `environment`). Mutations return an explicit `forbidden` error.
 - **Proposed-attribute checks** apply to `create*` mutations: the resolver synthesizes the would-be entity's effective attributes (cascaded parent attrs + the entity's own `md-id` and local identifier) and checks ABAC against that map. This lets policies gate creation by name (`md-environment: [dev, staging, prod]`).
-- **Org admin bypass** applies everywhere — a member of the `organization:admin` group skips every check on this page.
+- **Built-in admin group satisfies every check by policy.** The built-in `organization.admin` group is seeded with one `allow` policy per catalog action (`conditions: nil`), so its members pass every gate on this page through the normal evaluation path — there is no engine bypass. Policies on the built-in admin and viewer groups are fixed and cannot be created, updated, deleted, or renamed.
 
 ## See also
 

--- a/docs/platform-operations/security/03-graphql-permissions.md
+++ b/docs/platform-operations/security/03-graphql-permissions.md
@@ -272,7 +272,7 @@ The single-entity counterpart (`project`, `ociRepo`, `resource`) explicitly chec
 
 - **`forbidden` is masked as `not_found`** for read paths that need to obscure existence (e.g., `project`, `environment`). Mutations return an explicit `forbidden` error.
 - **Proposed-attribute checks** apply to `create*` mutations: the resolver synthesizes the would-be entity's effective attributes (cascaded parent attrs + the entity's own `md-id` and local identifier) and checks ABAC against that map. This lets policies gate creation by name (`md-environment: [dev, staging, prod]`).
-- **Built-in admin group satisfies every check by policy.** The built-in `organization.admin` group is seeded with one `allow` policy per catalog action (`conditions: nil`), so its members pass every gate on this page through the normal evaluation path — there is no engine bypass. Policies on the built-in admin and viewer groups are fixed and cannot be created, updated, deleted, or renamed.
+- **Built-in admin group has full access.** Members of the built-in `organization.admin` group pass every gate on this page. The built-in admin and viewer groups are fixed — you can't author policies on them, rename them, or delete them. Use a custom group for everything else.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Mirrors the ABAC engine change shipping in massdriver-cloud/massdriver#3267 (issue #3238). Three load-bearing engine changes are now reflected in the public docs:

1. **`organization:view` is gone.** Reading the org's public profile (name, logo, identifier) and any "is this person a member" check is implicit from group membership — no policy required.
2. **`organization:manage` is now a one-level umbrella** covering 7 new sub-actions: `manageServiceAccounts`, `manageGroups`, `manageBilling`, `manageIntegrations`, `manageCustomAttributes`, `manageResourceTypes`, `manageProfile`. A single policy granting the umbrella satisfies any sub-action query via the engine's umbrella rule. Holding a single sub-action does **not** imply the umbrella.
3. **The `is_org_admin?` engine bypass is gone.** The built-in `organization.admin` group is now privileged by data: at org-creation time, one `allow` policy per catalog action is seeded onto the group with `conditions: nil`. There is no special-case in the engine. Policies on the built-in admin and viewer groups cannot be created, updated, deleted, or renamed.

## Files

- `docs/platform-operations/security/02-access-control.md` — Evaluation Rules, reachability table (adds `organization` row), Resource Type section, Organization permission table (umbrella + 7 sub-actions), and the Built-in Administration section. Permission count bumped 34 → 39.
- `docs/platform-operations/security/03-graphql-permissions.md` — every row that previously named `organization:view` or `organization:manage` re-pointed per the new mapping. Added an umbrella note near the top. Split `auditLogs` / `auditLog` into project-scoped vs org-level. Rewrote the "Org admin bypass" line in Conventions to describe the seeded-policy model.

The autogenerated `docs/api/graphql/operations/**` MDX files are not touched — those regenerate from the published GraphQL schema.

## Test plan

- [ ] Visual review in the docusaurus preview — the new Organization permission table, the reachability-table `organization` row, and the per-mutation re-pointing all render cleanly.
- [ ] Spot-check no stray `organization:view` or "Org admin bypass" language survives in the two edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)