### PR TITLE
docs: rollback workflow guide + abac access-control catalog drift

### DIFF
--- a/docs/platform-operations/security/02-access-control.md
+++ b/docs/platform-operations/security/02-access-control.md
@@ -309,8 +309,10 @@ Massdriver defines 39 permissions using an `entity:verb` format.
 |---|---|
 | `environment:create` | Create an environment in a project |
 | `environment:update` | Update environment name, description, and attributes |
-| `environment:delete` | Delete an environment |
+| `environment:delete` | Delete an empty environment — instances must be decommissioned first |
 | `environment:configure` | Set or remove environment-level resource defaults |
+| `environment:deploy` | Deploy every instance in an environment, in dependency order. Re-triggering an in-flight environment deployment cancels and replaces the prior run. |
+| `environment:decommission` | Decommission every instance in an environment, in reverse dependency order. The environment shell is kept so it can be redeployed. |
 
 ### Instance
 
@@ -320,7 +322,7 @@ Massdriver defines 39 permissions using an `entity:verb` format.
 | `instance:deploy` | Deploy infrastructure. Also approves or rejects proposed deployments — anyone who can deploy an instance can decide a proposal for it. |
 | `instance:plan` | Run an infrastructure plan without deploying |
 | `instance:decommission` | Tear down infrastructure |
-| `instance:propose` | Submit a deployment for approval |
+| `instance:propose` | Submit a deployment for approval, including a rollback proposal that returns the instance to a past deployment's exact state. Approving or rejecting the proposal is gated by `instance:deploy` — anyone who can deploy can also decide a proposal. |
 
 ### Group
 
@@ -405,7 +407,7 @@ policies:
 
 ### SRE with Cross-Cutting Production Access
 
-SRE can see all projects and deploy, decommission, or approve proposed deployments anywhere in production. `instance:deploy` covers both running a deployment and deciding a proposal submitted by another team.
+SRE can see all projects and deploy, decommission, propose rollbacks, or approve proposed deployments anywhere in production. `instance:deploy` covers both running a deployment and deciding a proposal — including rollback proposals — submitted by another team. `instance:propose` lets SRE author rollback proposals themselves when paging through an incident.
 
 ```yaml
 group: sre
@@ -415,8 +417,12 @@ policies:
     conditions: "*"
 
   - effect: allow
-    action: [instance:deploy, instance:decommission]
-    conditions: { md-environment: production }
+    action: [instance:deploy, instance:decommission, instance:propose]
+    conditions: { md-environment: [production] }
+
+  - effect: allow
+    action: [environment:deploy, environment:decommission]
+    conditions: { md-environment: [production] }
 ```
 
 ### Read-Only Auditor

--- a/docs/workflows/00-overview.md
+++ b/docs/workflows/00-overview.md
@@ -48,6 +48,10 @@ primitives either way.
   Forks the base env, pins environment defaults, applies per-instance
   overrides, and deploys — every step idempotent, so re-running
   converges the env back to the declared state.
+- **[Roll back a deployment](/workflows/rollback)** — return an instance
+  to a past deployment's exact bundle version, params, and connection
+  wiring. The mutation produces a proposal that goes through the same
+  review gate as any other change to production.
 
 ## API and CLI as a framework on the platform you're building
 

--- a/docs/workflows/04-rollback.md
+++ b/docs/workflows/04-rollback.md
@@ -9,57 +9,53 @@ sidebar_label: Roll Back
 
 A **rollback** returns an instance to the state of a past deployment —
 same bundle version, same params, same connection wiring — as a
-*proposal*. Nothing ships until someone with deploy authority approves
-it, so the rollback follows the same review path as any other change to
-the instance.
+proposal. The proposal goes through the same approval gate as any other
+change to the instance; nothing ships until an approver with deploy
+authority approves it.
 
 Use a rollback when:
 
 - A deploy left an instance in a bad state and you want to return to
   the last known-good run.
-- An upgrade made it through staging but misbehaves under production
-  load and you want to step it back to the prior version with the same
-  params it had then.
+- An upgrade reached production and misbehaves under load, and you
+  want to step it back to the prior version with the params it had
+  then.
 - You're rehearsing an incident response and want to verify the
   rollback path before you need it.
 
 A rollback is not the right tool for "deploy a slightly older bundle
 version." For that, edit the instance's version constraint and run
-`deployInstance`. A rollback specifically reproduces the snapshot of a
+`deployInstance`. A rollback reproduces the snapshot of a specific
 past run.
 
-## What `rollbackDeployment` actually does
+## `rollbackDeployment`
 
 One API call, atomic:
 
-1. Validates the source — it must be a `COMPLETED` `PROVISION`
-   deployment. You cannot roll back to a `FAILED`, `PROPOSED`, or
-   `DECOMMISSION` deployment, and you cannot roll back to a deployment
-   from a different instance.
+1. Validates the source. It must be a `COMPLETED` `PROVISION`
+   deployment on the same instance. `FAILED`, `PROPOSED`, and
+   `DECOMMISSION` deployments are rejected.
 2. Snapshots the source's user params. The `md_metadata` block is
-   refreshed against the current package; everything else is carried
+   regenerated against the current package; the rest is carried
    verbatim.
 3. Snapshots the source's `connection_params` — the resolved IDs of
    the connections the instance was wired to at the time of the source
    run.
-4. Carries the source's bundle release pointer (`bundle_release_id`)
-   and `version` forward.
+4. Carries the source's `bundle_release_id` and `version` forward.
 5. Creates a new `PROPOSED` `PROVISION` deployment with the above and
    records `rollbackOf` pointing at the source.
 
-The result is a regular proposed deployment. It can be approved
-(`approveDeployment`), rejected (`rejectDeployment`), or have a plan
-run against it (`planDeployment`) — the same surface as any other
-proposal.
+The result is a proposed deployment. It accepts `approveDeployment`,
+`rejectDeployment`, and `planDeployment` — the same surface as any
+other proposal.
 
-### On approval
+### Approval
 
-`approveDeployment` on a rollback proposal does one extra thing beyond
-a normal approval: it pins the package's bundle release pointer
-(`bundle_release_id` and `version`) to the source's. The instance ends
-up running the snapshot *and* configured with the snapshot's release as
-its current release, so subsequent edits compose on top of the
-rolled-back state.
+`approveDeployment` on a rollback proposal pins the package's
+`bundle_release_id` and `version` to the source's, in addition to the
+normal apply. After approval, the instance is running the snapshot and
+the package's configured release is the snapshot's release, so
+subsequent edits compose on top of the rolled-back state.
 
 ## The mutation
 
@@ -82,19 +78,19 @@ mutation Rollback($orgId: ID!, $sourceDeploymentId: UUID!) {
 }
 ```
 
-`id` is the **source** — the historical deployment you want to return
-to. The mutation returns the new proposal; pass its `id` to
-`approveDeployment` / `rejectDeployment` / `planDeployment`.
+`id` is the **source** — the historical deployment to return to. The
+mutation returns the new proposal; pass its `id` to
+`approveDeployment`, `rejectDeployment`, or `planDeployment`.
 
 ### Authorization
 
 - Proposing the rollback requires `instance:propose` on the instance —
   the same gate as any other proposal.
 - Approving or rejecting requires `instance:deploy` on the instance.
-  There is no separate "rollback approval" permission.
+  There is no separate rollback-approval permission.
 
-For incident response, granting SREs `instance:propose` +
-`instance:deploy` in production (see the [ABAC SRE
+Granting SREs `instance:propose` and `instance:deploy` in production
+(see the [ABAC SRE
 example](/platform-operations/security/access-control#sre-with-cross-cutting-production-access))
 lets an oncall engineer author and approve a rollback without waiting
 for another team.
@@ -102,8 +98,8 @@ for another team.
 ## The flow
 
 ```graphql
-# 1. Find the deployment you want to return to. The most recent
-#    completed provision is the usual answer.
+# 1. Find the deployment to return to. The most recent completed
+#    provision is the usual answer.
 query LastGoodDeployment($instanceId: ID!) {
   instance(id: $instanceId) {
     deployments(
@@ -127,8 +123,8 @@ mutation {
   }
 }
 
-# 3. (Optional) Run a plan against the proposal to see the diff before
-#    approving. A normal planDeployment — no rollback-specific behavior.
+# 3. Optional. Run a plan against the proposal to see the diff before
+#    approving. Standard planDeployment; no rollback-specific behavior.
 mutation {
   planDeployment(organizationId: "acme", id: "$proposalId") {
     successful
@@ -136,8 +132,8 @@ mutation {
   }
 }
 
-# 4. Approve. This step ships the deployment and pins the package's
-#    release pointer to the source's.
+# 4. Approve. Ships the deployment and pins the package's release
+#    pointer to the source's.
 mutation {
   approveDeployment(organizationId: "acme", id: "$proposalId") {
     successful
@@ -146,63 +142,58 @@ mutation {
 }
 ```
 
-If the rollback turns out to be the wrong call mid-review,
-`rejectDeployment` takes the proposal out of contention. The instance
-never moved, and the audit log captures both the proposal and the
-rejection.
+`rejectDeployment` discards the proposal. The instance is not
+modified; the proposal and rejection both appear in the audit log.
 
-## What does — and doesn't — get snapshotted
+## Snapshot behavior
 
 | Source's value | What ends up on the rollback proposal |
 |---|---|
 | `params` (your config) | Verbatim, minus `md_metadata` |
-| `md_metadata` (platform-injected) | Re-generated from current package state |
+| `md_metadata` (platform-injected) | Regenerated from current package state |
 | `connection_params` (resolved connections) | Verbatim |
 | `version` | Verbatim |
 | `bundle_release_id` (which published bundle) | Verbatim |
 | `release` (release-channel pointer) | Verbatim |
-| `secrets` | Not part of a deployment — the instance's current secrets apply. Rollback doesn't touch them. |
+| `secrets` | Not part of a deployment — the instance's current secrets apply. Rollback does not touch them. |
 
-The asymmetry between `md_metadata` (refreshed) and everything else
-(snapshotted) is deliberate. `md_metadata` describes the platform
-context — org, project, environment, instance identity — and that
-context shouldn't roll back with the config. If the instance has moved
-environments or been renamed since the source run, the metadata
-reflects the current state. Everything you authored rolls back; the
-plumbing stays current.
+`md_metadata` is regenerated because it describes the platform context
+— org, project, environment, instance identity — and that context
+should reflect the current state of the instance, not the source's. If
+the instance has been renamed or moved environments since the source
+run, the regenerated metadata reflects the current location.
 
-## What rollback doesn't do
+## Limits
 
-- **It doesn't move secrets.** Secrets live on the instance, not on
-  deployments. If the failing deploy was caused by a secret change,
-  revert the secret separately.
-- **It doesn't migrate data.** A bundle version that altered a schema
-  on the way up may not have a working migration on the way down.
-  Rollback returns the bundle and params; it does not generate or run
-  reverse migrations.
-- **It doesn't decommission anything.** Resources the failing
-  deployment created that don't exist in the snapshot are removed by
-  the next provision (the rollback's `PROVISION` run reconciles
-  state); resources created outside of Massdriver are not.
-- **It can't skip the approval gate.** Even authors with
-  `instance:deploy` go through `approveDeployment`. The approval step
-  is what creates the audit record.
+- **Secrets are not rolled back.** Secrets live on the instance, not
+  on deployments. If a secret change caused the failure, revert it
+  separately.
+- **Data is not migrated.** A bundle version that altered a schema on
+  the way up may not have a working migration on the way down.
+  Rollback restores the bundle and params; it does not generate or
+  run reverse migrations.
+- **Out-of-band resources are not decommissioned.** Resources the
+  failing deployment created that are absent from the snapshot are
+  removed by the rollback's `PROVISION` run, which reconciles state.
+  Resources created outside Massdriver are not.
+- **The approval gate cannot be skipped.** Authors with
+  `instance:deploy` still go through `approveDeployment`. The
+  approval step is what creates the audit record.
 
-## Why approval pins the release pointer
+## Release-pointer pinning
 
-A normal provision deployment applies a configuration but leaves the
-package's `bundle_release_id` / `version` pointer wherever the user
-left it, so the next edit composes against the latest intent.
+A normal provision deployment applies a configuration without changing
+the package's `bundle_release_id` or `version` pointer. The next edit
+composes against the pointer the user last set.
 
-A rollback rewrites that pointer to the source's. The reasoning: if
-the source's run is the desired state, the instance's configured
-release should reflect that. Otherwise the next deploy would compose
-against the broken release, and the rollback would be a one-shot patch
-instead of a return to a known state.
+A rollback approval rewrites that pointer to the source's. Without the
+rewrite, the next deploy would compose against the release the
+rollback was meant to retreat from, and the rollback would behave as a
+one-shot patch rather than a return to a known state.
 
-For one-shot behavior — deploy this snapshot once, but keep the
-current pinned version — propose the deployment manually with
-`proposeDeployment` rather than `rollbackDeployment`.
+For one-shot behavior — apply this snapshot once, keep the current
+pinned version — use `proposeDeployment` directly instead of
+`rollbackDeployment`.
 
 ## Reference
 

--- a/docs/workflows/04-rollback.md
+++ b/docs/workflows/04-rollback.md
@@ -1,0 +1,218 @@
+---
+id: workflow-rollback
+slug: /workflows/rollback
+title: Roll Back a Deployment
+sidebar_label: Roll Back
+---
+
+# Roll Back a Deployment
+
+A **rollback** returns an instance to the exact state of a past
+deployment — same bundle version, same params, same connection wiring —
+*as a proposal*. Nothing ships until someone with deploy authority
+approves it. The intent is "treat rollback like every other change to
+production: deliberate, reviewable, audit-logged" — not "let one person
+flip prod back to whatever yesterday looked like."
+
+Use a rollback when:
+
+- A deploy left an instance in a bad state and you want to return to the
+  last known-good run.
+- An upgrade made it through staging but mis-behaves under prod load and
+  you want to step it back to the prior pinned version *with the same
+  params it had then*.
+- You're rehearsing an incident response and want to verify the rollback
+  path works end-to-end before you need it.
+
+It is **not** the right tool for "deploy a slightly older bundle version"
+— for that, edit the instance's version constraint and run
+`deployInstance`. A rollback specifically reproduces the snapshot of a
+past run.
+
+## What `rollbackDeployment` actually does
+
+One API call, atomic:
+
+1. Validates the source — must be a `COMPLETED` `PROVISION` deployment.
+   You cannot roll back to a `FAILED`, `PROPOSED`, or `DECOMMISSION`
+   deployment, and you cannot roll back to a deployment from a different
+   instance.
+2. Snapshots the source's user params (the `md_metadata` block is
+   refreshed against the current package, but everything you set stays
+   verbatim).
+3. Snapshots the source's `connection_params` — the resolved IDs of the
+   connections the instance was wired to at the time of the source run.
+4. Carries the source's bundle release pointer (`bundle_release_id`) and
+   `version` forward.
+5. Creates a new `PROPOSED` `PROVISION` deployment with all of the above
+   and records `rollbackOf` pointing at the source.
+
+The result is a regular proposed deployment. It can be approved
+(`approveDeployment`), rejected (`rejectDeployment`), or have a plan run
+against it (`planDeployment`) — the same surface as any other proposal.
+
+### On approval
+
+`approveDeployment` on a rollback proposal does one extra thing beyond a
+normal approval: it **pins the package's bundle release pointer**
+(`bundle_release_id` and `version`) to the source's. The instance ends
+up not just running the snapshot, but *configured* with the snapshot's
+release as its current release — so subsequent edits compose on top of
+the rolled-back state, not the broken one.
+
+This is the difference between "deploy this once" and "make this the
+state of the instance." A rollback is the second.
+
+## The mutation
+
+```graphql
+mutation Rollback($orgId: ID!, $sourceDeploymentId: UUID!) {
+  rollbackDeployment(
+    organizationId: $orgId
+    id: $sourceDeploymentId
+  ) {
+    successful
+    result {
+      id
+      status         # always PROPOSED
+      action         # always PROVISION
+      message        # auto-generated "Rollback to deployment <id> (v<version>) ..."
+      rollbackOf { id version }
+    }
+    messages { field message }
+  }
+}
+```
+
+`id` is the **source** — the historical deployment you want to return
+to. The mutation returns the new proposal; pass its `id` to
+`approveDeployment` / `rejectDeployment` / `planDeployment`.
+
+### Authorization
+
+- Proposing the rollback requires `instance:propose` on the instance —
+  same as any other proposal.
+- Approving or rejecting requires `instance:deploy` on the instance —
+  the same gate that decides any other proposal. There is no separate
+  "rollback approval" permission.
+
+A pattern that works for incident response: SRE has `instance:propose` +
+`instance:deploy` in production via the [ABAC SRE
+example](/platform-operations/security/access-control#sre-with-cross-cutting-production-access),
+so an oncall engineer can author *and* approve a rollback without
+waiting for another team.
+
+## The flow
+
+```graphql
+# 1. Find the deployment you want to return to. Most recently completed
+#    provision is the usual answer.
+query LastGoodDeployment($instanceId: ID!) {
+  instance(id: $instanceId) {
+    deployments(
+      first: 5
+      filter: { action: PROVISION, status: COMPLETED }
+      sortBy: CREATED_AT
+      sortOrder: DESC
+    ) {
+      edges {
+        node { id version message createdAt }
+      }
+    }
+  }
+}
+
+# 2. Propose the rollback against that source deployment's id.
+mutation {
+  rollbackDeployment(organizationId: "acme", id: "$sourceDeploymentId") {
+    successful
+    result { id rollbackOf { id version } }
+  }
+}
+
+# 3. (Optional) Run a plan against the proposal to see the diff before
+#    approving. This is a normal planDeployment — no rollback-specific
+#    behavior.
+mutation {
+  planDeployment(organizationId: "acme", id: "$proposalId") {
+    successful
+    result { id status }
+  }
+}
+
+# 4. Approve. This is the step that ships and pins the package's release
+#    pointer to the source's.
+mutation {
+  approveDeployment(organizationId: "acme", id: "$proposalId") {
+    successful
+    result { id status }
+  }
+}
+```
+
+If the rollback turns out to be the wrong call mid-review, `rejectDeployment`
+takes the proposal out of contention. The instance never moved, and the
+audit log captures both the proposal and the rejection.
+
+## What does — and doesn't — get snapshotted
+
+| Source's value | What ends up on the rollback proposal |
+|---|---|
+| `params` (your config) | Verbatim, minus `md_metadata` |
+| `md_metadata` (platform-injected) | Re-generated from current package state |
+| `connection_params` (resolved connections) | Verbatim |
+| `version` | Verbatim |
+| `bundle_release_id` (which published bundle) | Verbatim |
+| `release` (release-channel pointer) | Verbatim |
+| `secrets` | **Not part of a deployment** — the instance's current secrets apply. Rollback doesn't touch them. |
+
+The asymmetry between `md_metadata` (refreshed) and everything else
+(snapshotted) is deliberate. `md_metadata` describes the platform
+context — org, project, environment, instance identity — and that
+context shouldn't roll back when you roll back the config. If the
+instance has moved environments or been renamed since the source run,
+the metadata reflects *now*. Everything you authored rolls back; the
+plumbing stays current.
+
+## What rollback doesn't do
+
+- **It doesn't move secrets.** Secrets live on the instance, not on
+  deployments. If the failing deploy was caused by a secret change,
+  also revert the secret — rollback alone won't.
+- **It doesn't migrate data.** A bundle version that altered a schema
+  on the way *up* may not have a working migration on the way *down*.
+  Rollback returns the bundle and params; it does not generate or run
+  reverse migrations. Treat data-bearing instances accordingly.
+- **It doesn't decommission anything.** Resources the failing
+  deployment created that don't exist in the snapshot are removed by
+  the next provision (the rollback's `PROVISION` run reconciles
+  state); resources created *outside* of Massdriver are not.
+- **It can't skip the approval gate.** Even authors with
+  `instance:deploy` go through `approveDeployment`. The audit log of
+  rollbacks is the value here, not the keystroke saved.
+
+## Why pin the release pointer?
+
+The non-obvious choice is what approval does to the package. A normal
+provision deployment applies a configuration but leaves the package's
+`bundle_release_id` / `version` pointer wherever the user left it — so
+your next edit composes against your latest intent.
+
+A rollback intentionally rewrites that pointer to the source's. The
+reasoning: if you've decided yesterday's run was the right state, then
+the instance's *configured release* should reflect that. Otherwise the
+next deploy would come from a still-broken `bundle_release_id`, and
+"rollback" would be a one-shot patch instead of a return to a known
+state.
+
+If you want one-shot behavior — deploy this snapshot once, but keep my
+current pinned version — propose the deployment manually with
+`proposeDeployment` rather than `rollbackDeployment`.
+
+## Reference
+
+- API mutation: `rollbackDeployment` in the V2 schema.
+- Related mutations: `proposeDeployment`, `approveDeployment`,
+  `rejectDeployment`, `planDeployment`.
+- Permissions: [`instance:propose` and `instance:deploy`](/platform-operations/security/access-control#instance).
+- Concept: [Deployments](/concepts/deployments).

--- a/docs/workflows/04-rollback.md
+++ b/docs/workflows/04-rollback.md
@@ -7,25 +7,24 @@ sidebar_label: Roll Back
 
 # Roll Back a Deployment
 
-A **rollback** returns an instance to the exact state of a past
-deployment — same bundle version, same params, same connection wiring —
-*as a proposal*. Nothing ships until someone with deploy authority
-approves it. The intent is "treat rollback like every other change to
-production: deliberate, reviewable, audit-logged" — not "let one person
-flip prod back to whatever yesterday looked like."
+A **rollback** returns an instance to the state of a past deployment —
+same bundle version, same params, same connection wiring — as a
+*proposal*. Nothing ships until someone with deploy authority approves
+it, so the rollback follows the same review path as any other change to
+the instance.
 
 Use a rollback when:
 
-- A deploy left an instance in a bad state and you want to return to the
-  last known-good run.
-- An upgrade made it through staging but mis-behaves under prod load and
-  you want to step it back to the prior pinned version *with the same
-  params it had then*.
-- You're rehearsing an incident response and want to verify the rollback
-  path works end-to-end before you need it.
+- A deploy left an instance in a bad state and you want to return to
+  the last known-good run.
+- An upgrade made it through staging but misbehaves under production
+  load and you want to step it back to the prior version with the same
+  params it had then.
+- You're rehearsing an incident response and want to verify the
+  rollback path before you need it.
 
-It is **not** the right tool for "deploy a slightly older bundle version"
-— for that, edit the instance's version constraint and run
+A rollback is not the right tool for "deploy a slightly older bundle
+version." For that, edit the instance's version constraint and run
 `deployInstance`. A rollback specifically reproduces the snapshot of a
 past run.
 
@@ -33,35 +32,34 @@ past run.
 
 One API call, atomic:
 
-1. Validates the source — must be a `COMPLETED` `PROVISION` deployment.
-   You cannot roll back to a `FAILED`, `PROPOSED`, or `DECOMMISSION`
-   deployment, and you cannot roll back to a deployment from a different
-   instance.
-2. Snapshots the source's user params (the `md_metadata` block is
-   refreshed against the current package, but everything you set stays
-   verbatim).
-3. Snapshots the source's `connection_params` — the resolved IDs of the
-   connections the instance was wired to at the time of the source run.
-4. Carries the source's bundle release pointer (`bundle_release_id`) and
-   `version` forward.
-5. Creates a new `PROPOSED` `PROVISION` deployment with all of the above
-   and records `rollbackOf` pointing at the source.
+1. Validates the source — it must be a `COMPLETED` `PROVISION`
+   deployment. You cannot roll back to a `FAILED`, `PROPOSED`, or
+   `DECOMMISSION` deployment, and you cannot roll back to a deployment
+   from a different instance.
+2. Snapshots the source's user params. The `md_metadata` block is
+   refreshed against the current package; everything else is carried
+   verbatim.
+3. Snapshots the source's `connection_params` — the resolved IDs of
+   the connections the instance was wired to at the time of the source
+   run.
+4. Carries the source's bundle release pointer (`bundle_release_id`)
+   and `version` forward.
+5. Creates a new `PROPOSED` `PROVISION` deployment with the above and
+   records `rollbackOf` pointing at the source.
 
 The result is a regular proposed deployment. It can be approved
-(`approveDeployment`), rejected (`rejectDeployment`), or have a plan run
-against it (`planDeployment`) — the same surface as any other proposal.
+(`approveDeployment`), rejected (`rejectDeployment`), or have a plan
+run against it (`planDeployment`) — the same surface as any other
+proposal.
 
 ### On approval
 
-`approveDeployment` on a rollback proposal does one extra thing beyond a
-normal approval: it **pins the package's bundle release pointer**
+`approveDeployment` on a rollback proposal does one extra thing beyond
+a normal approval: it pins the package's bundle release pointer
 (`bundle_release_id` and `version`) to the source's. The instance ends
-up not just running the snapshot, but *configured* with the snapshot's
-release as its current release — so subsequent edits compose on top of
-the rolled-back state, not the broken one.
-
-This is the difference between "deploy this once" and "make this the
-state of the instance." A rollback is the second.
+up running the snapshot *and* configured with the snapshot's release as
+its current release, so subsequent edits compose on top of the
+rolled-back state.
 
 ## The mutation
 
@@ -91,22 +89,21 @@ to. The mutation returns the new proposal; pass its `id` to
 ### Authorization
 
 - Proposing the rollback requires `instance:propose` on the instance —
-  same as any other proposal.
-- Approving or rejecting requires `instance:deploy` on the instance —
-  the same gate that decides any other proposal. There is no separate
-  "rollback approval" permission.
+  the same gate as any other proposal.
+- Approving or rejecting requires `instance:deploy` on the instance.
+  There is no separate "rollback approval" permission.
 
-A pattern that works for incident response: SRE has `instance:propose` +
-`instance:deploy` in production via the [ABAC SRE
-example](/platform-operations/security/access-control#sre-with-cross-cutting-production-access),
-so an oncall engineer can author *and* approve a rollback without
-waiting for another team.
+For incident response, granting SREs `instance:propose` +
+`instance:deploy` in production (see the [ABAC SRE
+example](/platform-operations/security/access-control#sre-with-cross-cutting-production-access))
+lets an oncall engineer author and approve a rollback without waiting
+for another team.
 
 ## The flow
 
 ```graphql
-# 1. Find the deployment you want to return to. Most recently completed
-#    provision is the usual answer.
+# 1. Find the deployment you want to return to. The most recent
+#    completed provision is the usual answer.
 query LastGoodDeployment($instanceId: ID!) {
   instance(id: $instanceId) {
     deployments(
@@ -131,8 +128,7 @@ mutation {
 }
 
 # 3. (Optional) Run a plan against the proposal to see the diff before
-#    approving. This is a normal planDeployment — no rollback-specific
-#    behavior.
+#    approving. A normal planDeployment — no rollback-specific behavior.
 mutation {
   planDeployment(organizationId: "acme", id: "$proposalId") {
     successful
@@ -140,8 +136,8 @@ mutation {
   }
 }
 
-# 4. Approve. This is the step that ships and pins the package's release
-#    pointer to the source's.
+# 4. Approve. This step ships the deployment and pins the package's
+#    release pointer to the source's.
 mutation {
   approveDeployment(organizationId: "acme", id: "$proposalId") {
     successful
@@ -150,9 +146,10 @@ mutation {
 }
 ```
 
-If the rollback turns out to be the wrong call mid-review, `rejectDeployment`
-takes the proposal out of contention. The instance never moved, and the
-audit log captures both the proposal and the rejection.
+If the rollback turns out to be the wrong call mid-review,
+`rejectDeployment` takes the proposal out of contention. The instance
+never moved, and the audit log captures both the proposal and the
+rejection.
 
 ## What does — and doesn't — get snapshotted
 
@@ -164,48 +161,46 @@ audit log captures both the proposal and the rejection.
 | `version` | Verbatim |
 | `bundle_release_id` (which published bundle) | Verbatim |
 | `release` (release-channel pointer) | Verbatim |
-| `secrets` | **Not part of a deployment** — the instance's current secrets apply. Rollback doesn't touch them. |
+| `secrets` | Not part of a deployment — the instance's current secrets apply. Rollback doesn't touch them. |
 
 The asymmetry between `md_metadata` (refreshed) and everything else
 (snapshotted) is deliberate. `md_metadata` describes the platform
 context — org, project, environment, instance identity — and that
-context shouldn't roll back when you roll back the config. If the
-instance has moved environments or been renamed since the source run,
-the metadata reflects *now*. Everything you authored rolls back; the
+context shouldn't roll back with the config. If the instance has moved
+environments or been renamed since the source run, the metadata
+reflects the current state. Everything you authored rolls back; the
 plumbing stays current.
 
 ## What rollback doesn't do
 
 - **It doesn't move secrets.** Secrets live on the instance, not on
   deployments. If the failing deploy was caused by a secret change,
-  also revert the secret — rollback alone won't.
+  revert the secret separately.
 - **It doesn't migrate data.** A bundle version that altered a schema
-  on the way *up* may not have a working migration on the way *down*.
+  on the way up may not have a working migration on the way down.
   Rollback returns the bundle and params; it does not generate or run
-  reverse migrations. Treat data-bearing instances accordingly.
+  reverse migrations.
 - **It doesn't decommission anything.** Resources the failing
   deployment created that don't exist in the snapshot are removed by
   the next provision (the rollback's `PROVISION` run reconciles
-  state); resources created *outside* of Massdriver are not.
+  state); resources created outside of Massdriver are not.
 - **It can't skip the approval gate.** Even authors with
-  `instance:deploy` go through `approveDeployment`. The audit log of
-  rollbacks is the value here, not the keystroke saved.
+  `instance:deploy` go through `approveDeployment`. The approval step
+  is what creates the audit record.
 
-## Why pin the release pointer?
+## Why approval pins the release pointer
 
-The non-obvious choice is what approval does to the package. A normal
-provision deployment applies a configuration but leaves the package's
-`bundle_release_id` / `version` pointer wherever the user left it — so
-your next edit composes against your latest intent.
+A normal provision deployment applies a configuration but leaves the
+package's `bundle_release_id` / `version` pointer wherever the user
+left it, so the next edit composes against the latest intent.
 
-A rollback intentionally rewrites that pointer to the source's. The
-reasoning: if you've decided yesterday's run was the right state, then
-the instance's *configured release* should reflect that. Otherwise the
-next deploy would come from a still-broken `bundle_release_id`, and
-"rollback" would be a one-shot patch instead of a return to a known
-state.
+A rollback rewrites that pointer to the source's. The reasoning: if
+the source's run is the desired state, the instance's configured
+release should reflect that. Otherwise the next deploy would compose
+against the broken release, and the rollback would be a one-shot patch
+instead of a return to a known state.
 
-If you want one-shot behavior — deploy this snapshot once, but keep my
+For one-shot behavior — deploy this snapshot once, but keep the
 current pinned version — propose the deployment manually with
 `proposeDeployment` rather than `rollbackDeployment`.
 


### PR DESCRIPTION
## Summary

Two related additions:

1. **New workflow guide: \`/workflows/rollback\`** — modeled on the depth and shape of the existing fork / promote / preview guides. Covers what \`rollbackDeployment\` actually does (snapshot semantics, what gets carried forward vs. refreshed), the approval flow, why approval pins the package release pointer, authorization (\`instance:propose\` to author, \`instance:deploy\` to approve), and the cases where rollback is the wrong tool (down-migrations, secret reverts, one-shot deploys).

2. **Access-Control page drift fix** — same content the in-repo \`docs/guides/abac.md\` got in [massdriver#3284](https://github.com/massdriver-cloud/massdriver/pull/3284):
   - Adds \`environment:deploy\` and \`environment:decommission\` to the Environment table (already in the action catalog, missing from this page).
   - Calls out rollback proposals under the \`instance:propose\` description.
   - Tightens \`environment:delete\` description (empty environment required).
   - Updates the SRE common-pattern example to include \`instance:propose\` + env-level deploy/decommission — the pattern the rollback guide references when describing oncall \"author + approve\" flows.

### Files

- new: \`docs/workflows/04-rollback.md\`
- modified: \`docs/workflows/00-overview.md\` — add rollback bullet to the section index
- modified: \`docs/platform-operations/security/02-access-control.md\`

## Test plan

- [ ] Docusaurus build is clean (sidebar order, slug routing for \`/workflows/rollback\`)
- [ ] Cross-references to \`/platform-operations/security/access-control#instance\` and \`#sre-with-cross-cutting-production-access\` resolve
- [ ] Skim rollback guide for parity with fork / promote / preview tone
- [ ] Confirm GraphQL examples reference real V2 fields (\`rollbackOf\`, \`status\`, \`action\`)

## Out of scope (deliberate)

- The \`Organization\` umbrella + 7 \`organization:manage*\` sub-actions listed on this page don't exist in the \`actionCatalog\` (the engine only has \`organization:manage\`). That divergence pre-dates this PR — leaving it for a dedicated sync pass.
- The page's \"imported resources carry user attributes\" claim diverges from the in-repo doc, but again — outside the rollback / env-actions scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)